### PR TITLE
feat: add plane sun visualization

### DIFF
--- a/components/Inputs.tsx
+++ b/components/Inputs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import airportsData from "@/lib/airports.json";
 import type { Airport, Preference } from "@/lib/types";
 import IataCombo from "@/components/IataCombo";

--- a/components/PlaneSunViz.tsx
+++ b/components/PlaneSunViz.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState } from "react";
+import type { Sample } from "@/lib/types";
+import { sunPlaneRelation } from "@/lib/plane";
+
+interface Props {
+  samples: Sample[] | null;
+}
+
+export default function PlaneSunViz({ samples }: Props) {
+  const [index, setIndex] = useState(0);
+  if (!samples || samples.length === 0) return null;
+
+  const idx = Math.min(index, samples.length - 1);
+  const s = samples[idx];
+  const rel = sunPlaneRelation(s.az, s.course, s.alt);
+
+  const angleRad = (rel.relAz * Math.PI) / 180;
+  const radius = 45;
+  const sunX = Math.sin(angleRad) * radius;
+  const sunY = -Math.cos(angleRad) * radius;
+
+  const leftOpacity = rel.side === "A" ? rel.intensity : 0;
+  const rightOpacity = rel.side === "F" ? rel.intensity : 0;
+
+  return (
+    <div className="mt-4">
+      <div className="relative mx-auto h-32 w-56">
+        {/* glare overlays */}
+        <div className="absolute left-1/2 top-1/2 h-12 w-40 -translate-x-1/2 -translate-y-1/2 flex">
+          <div
+            className="h-full w-1/2 bg-yellow-300/60 transition-opacity"
+            style={{ opacity: leftOpacity }}
+          />
+          <div
+            className="h-full w-1/2 bg-yellow-300/60 transition-opacity"
+            style={{ opacity: rightOpacity }}
+          />
+        </div>
+
+        {/* plane silhouette */}
+        <svg
+          viewBox="0 0 200 80"
+          className="absolute left-1/2 top-1/2 h-20 w-40 -translate-x-1/2 -translate-y-1/2 fill-zinc-600 dark:fill-zinc-300"
+        >
+          <polygon points="100,0 120,20 80,20" />
+          <rect x="80" y="20" width="40" height="40" />
+          <polygon points="100,80 120,60 80,60" />
+          <rect x="40" y="30" width="40" height="20" />
+          <rect x="120" y="30" width="40" height="20" />
+        </svg>
+
+        {/* sun position */}
+        <div
+          className="absolute h-6 w-6 rounded-full bg-yellow-400 border border-yellow-500 shadow"
+          style={{
+            left: `calc(50% + ${sunX}px - 12px)`,
+            top: `calc(50% + ${sunY}px - 12px)`,
+          }}
+        />
+      </div>
+      {samples.length > 1 && (
+        <input
+          type="range"
+          min={0}
+          max={samples.length - 1}
+          value={idx}
+          onChange={(e) => setIndex(Number(e.target.value))}
+          className="mt-2 w-full"
+        />
+      )}
+    </div>
+  );
+}

--- a/components/ResultCard.tsx
+++ b/components/ResultCard.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import type { Recommendation, Airport, Preference } from "@/lib/types";
 import { formatLocal } from "@/lib/time";
 import SunSparkline from "@/components/SunSparkline";
+import PlaneSunViz from "@/components/PlaneSunViz";
 
 type Props = {
   rec: Recommendation | null;
@@ -110,6 +111,11 @@ export default function ResultCard({ rec, origin, dest, preference }: Props) {
         <div className="text-zinc-700 dark:text-zinc-200">
           <SunSparkline samples={rec.samples} />
         </div>
+      )}
+
+      {/* Plane sun visualization */}
+      {rec.samples && rec.samples.length > 0 && (
+        <PlaneSunViz samples={rec.samples} />
       )}
 
       {/* Actions */}

--- a/components/SunSparkline.tsx
+++ b/components/SunSparkline.tsx
@@ -74,7 +74,7 @@ export default function SunSparkline({ samples, height = 100 }: Props) {
       fullPath,
       sunPath,
     };
-  }, [samples, height]);
+  }, [samples, height, paddingTop]);
 
   if (!model) return null;
 

--- a/lib/geo.ts
+++ b/lib/geo.ts
@@ -6,7 +6,7 @@ const toDeg = (r: number) => (r * 180) / Math.PI;
 
 /** Normalize angle to (-180, 180] */
 export const wrapTo180 = (x: number) => {
-  let a = (((x + 180) % 360) + 360) % 360; // 0..360
+  const a = (((x + 180) % 360) + 360) % 360; // 0..360
   return a > 180 ? a - 360 : a;
 };
 

--- a/lib/plane.ts
+++ b/lib/plane.ts
@@ -1,0 +1,31 @@
+import { wrapTo180 } from "./geo";
+
+export type SunPlaneRelation = {
+  /** relative azimuth of sun from aircraft nose, degrees (-180..180) */
+  relAz: number;
+  /** which side of aircraft receives sun */
+  side: "A" | "F" | "none";
+  /** glare intensity 0..1 based on altitude */
+  intensity: number;
+};
+
+/**
+ * Determine sun side and glare intensity relative to aircraft course.
+ * @param az Sun azimuth in degrees (0..360 from north)
+ * @param course Aircraft course/bearing in degrees (0..360 from north)
+ * @param alt Sun altitude in degrees
+ */
+export function sunPlaneRelation(
+  az: number,
+  course: number,
+  alt: number
+): SunPlaneRelation {
+  const rel = wrapTo180(az - course);
+  const intensity = Math.max(0, Math.min(1, alt / 90));
+  let side: "A" | "F" | "none" = "none";
+  if (alt >= 5) {
+    side = rel > 0 ? "F" : "A";
+  }
+  return { relAz: rel, side, intensity };
+}
+

--- a/tests/plane.test.ts
+++ b/tests/plane.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { sunPlaneRelation } from "../lib/plane";
+
+describe("sunPlaneRelation", () => {
+  it("identifies sun on right (F)", () => {
+    const r = sunPlaneRelation(270, 0, 10); // sun west relative to northbound plane
+    expect(r.side).toBe("F");
+  });
+
+  it("identifies sun on left (A)", () => {
+    const r = sunPlaneRelation(90, 0, 10); // sun east relative to northbound plane
+    expect(r.side).toBe("A");
+  });
+
+  it("returns none when sun below horizon", () => {
+    const r = sunPlaneRelation(90, 0, 0);
+    expect(r.side).toBe("none");
+    expect(r.intensity).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add PlaneSunViz component for interactive sun/airplane view with glare intensity
- compute sun side and intensity via new sunPlaneRelation helper
- render visualization in ResultCard and test left/right positioning
- clean up lint warnings in Inputs and SunSparkline

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`
- `npx vitest run`


------