### PR TITLE
Fix inputs clear-all callback and map props

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -121,7 +121,7 @@ export default function Home() {
 
         <ResultCard rec={rec} origin={origin} dest={dest} preference={pref} />
 
-        <MapView samples={rec?.samples ?? null} cities={cityPassBys} thresholdKm={thresholdKm} originTZ={origin?.tz} />
+        <MapView samples={rec?.samples ?? null} cities={cityPassBys} thresholdKm={thresholdKm} />
 
         <footer className="text-xs text-zinc-500 dark:text-zinc-400 pt-2">
           Assumes great-circle routing and fair weather. Window seats: A (left),

--- a/components/Inputs.tsx
+++ b/components/Inputs.tsx
@@ -24,11 +24,12 @@ type Props = {
   onSubmit: (data: InputsSnapshot) => void;
   defaults?: Defaults;
   loading?: boolean;
+  onClearAll?: () => void;
 };
 type TZMode = "origin" | "dest" | "custom";
 type Recent = { from: string; to: string; depart: string };
 
-export default function Inputs({ onSubmit, defaults, loading = false }: Props) {
+export default function Inputs({ onSubmit, defaults, loading = false, onClearAll }: Props) {
   const [from, setFrom] = useState(defaults?.from ?? "");
   const [to, setTo] = useState(defaults?.to ?? "");
   const [depart, setDepart] = useState(defaults?.depart ?? "");
@@ -119,6 +120,7 @@ export default function Inputs({ onSubmit, defaults, loading = false }: Props) {
     try { localStorage.removeItem("ss_recent"); } catch {}
     setRecent([]);
     fromRef.current?.focus();
+    onClearAll?.();
   }
   function swap() {
     const old = from;


### PR DESCRIPTION
## Summary
- allow the Inputs component to notify callers when the form is cleared
- remove unsupported `originTZ` prop when rendering MapView on the home page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_689866f3ff48833399b39451b4ece987