### PR TITLE
feat: add plane visualization and restore sunrise/sunset metadata

### DIFF
--- a/components/Inputs.tsx
+++ b/components/Inputs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import airportsData from "@/lib/airports.json";
 import type { Airport, Preference } from "@/lib/types";
 import IataCombo from "@/components/IataCombo";

--- a/components/PlaneSunViz.tsx
+++ b/components/PlaneSunViz.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import type { Sample } from "@/lib/types";
+import { sunPlaneRelation } from "@/lib/plane";
+
+interface Props {
+  samples: Sample[] | null;
+}
+
+export default function PlaneSunViz({ samples }: Props) {
+  const [index, setIndex] = useState(0);
+  if (!samples || samples.length === 0) return null;
+
+  const idx = Math.min(index, samples.length - 1);
+  const s = samples[idx];
+  const rel = sunPlaneRelation(s.az, s.course, s.alt);
+
+  const angleRad = (rel.relAz * Math.PI) / 180;
+  const radius = 45;
+  const sunX = Math.sin(angleRad) * radius;
+  const sunY = -Math.cos(angleRad) * radius;
+
+  const leftOpacity = rel.side === "A" ? rel.intensity : 0;
+  const rightOpacity = rel.side === "F" ? rel.intensity : 0;
+
+  return (
+    <div className="mt-4">
+      <div className="relative mx-auto h-32 w-56">
+        {/* glare overlays */}
+        <div className="absolute left-1/2 top-1/2 h-12 w-40 -translate-x-1/2 -translate-y-1/2 flex">
+          <div
+            className="h-full w-1/2 bg-yellow-300/60 transition-opacity"
+            style={{ opacity: leftOpacity }}
+          />
+          <div
+            className="h-full w-1/2 bg-yellow-300/60 transition-opacity"
+            style={{ opacity: rightOpacity }}
+          />
+        </div>
+
+        {/* plane silhouette */}
+        <svg
+          viewBox="0 0 200 100"
+          className="absolute left-1/2 top-1/2 h-20 w-40 -translate-x-1/2 -translate-y-1/2 fill-zinc-600 dark:fill-zinc-300"
+        >
+          {/* nose */}
+          <polygon points="100,0 120,20 80,20" />
+          {/* fuselage */}
+          <rect x="80" y="20" width="40" height="50" />
+          {/* tail */}
+          <polygon points="100,100 120,70 80,70" />
+          {/* wings */}
+          <polygon points="100,35 180,55 180,65 100,45" />
+          <polygon points="100,35 20,55 20,65 100,45" />
+          {/* horizontal stabilizers */}
+          <polygon points="100,70 160,80 160,86 100,75" />
+          <polygon points="100,70 40,80 40,86 100,75" />
+        </svg>
+
+        {/* sun position */}
+        <div
+          className="absolute h-6 w-6 rounded-full bg-yellow-400 border border-yellow-500 shadow"
+          style={{
+            left: `calc(50% + ${sunX}px - 12px)`,
+            top: `calc(50% + ${sunY}px - 12px)`,
+          }}
+        />
+      </div>
+      {samples.length > 1 && (
+        <input
+          type="range"
+          min={0}
+          max={samples.length - 1}
+          value={idx}
+          onChange={(e) => setIndex(Number(e.target.value))}
+          aria-label="Time along flight"
+          className="mt-2 w-full cursor-pointer appearance-none accent-zinc-600 dark:accent-zinc-300 [&::-webkit-slider-runnable-track]:h-2 [&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-zinc-200 dark:[&::-webkit-slider-runnable-track]:bg-zinc-700 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-zinc-600 dark:[&::-webkit-slider-thumb]:bg-zinc-300"
+        />
+      )}
+    </div>
+  );
+}

--- a/components/ResultCard.tsx
+++ b/components/ResultCard.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import type { Recommendation, Airport, Preference } from "@/lib/types";
 import { formatLocal } from "@/lib/time";
 import SunSparkline from "@/components/SunSparkline";
+import PlaneSunViz from "@/components/PlaneSunViz";
 
 type Props = {
   rec: Recommendation | null;
@@ -33,8 +34,8 @@ export default function ResultCard({ rec, origin, dest, preference }: Props) {
 
   const rationale =
     preference === "avoid"
-      ? `minimizes direct sun (~${100 - sunPct}%)`
-      : `sun on that side for ~${sunPct}% of the flight`;
+      ? `keeps direct sun away for about ${100 - sunPct}% of the flight`
+      : `sun graces that side for roughly ${sunPct}% of the flight`;
 
   // Normalize whatever we got ("A", "F", "A (left)", "F (right)", etc.)
   const sideRaw = String(rec.side ?? "").trim();
@@ -66,7 +67,7 @@ export default function ResultCard({ rec, origin, dest, preference }: Props) {
       setCopied(true);
       setTimeout(() => setCopied(false), 1200);
     } catch {
-      window.prompt("Copy result:", textToCopy);
+      window.prompt("Copy recommendation:", textToCopy);
     }
   }
 
@@ -74,15 +75,14 @@ export default function ResultCard({ rec, origin, dest, preference }: Props) {
     <div className="relative p-5 bg-white dark:bg-zinc-800 rounded-2xl shadow border border-zinc-200 dark:border-zinc-700">
       <div className="mb-2">
         <span className="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium bg-zinc-100 dark:bg-zinc-700 text-zinc-700 dark:text-zinc-200">
-          Recommendation
+          Seat recommendation
         </span>
       </div>
 
       {/* Headline */}
       <h2 className="text-2xl font-extrabold tracking-tight">{headline}</h2>
       <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-300">
-        Peak sun altitude ~{rec.peakAltitudeDeg}° above horizon. Confidence{" "}
-        {Math.round(rec.confidence * 100)}%.
+        Peak sun altitude around {rec.peakAltitudeDeg}° above the horizon. Confidence {Math.round(rec.confidence * 100)}%.
       </p>
 
       {/* Info pills */}
@@ -112,15 +112,20 @@ export default function ResultCard({ rec, origin, dest, preference }: Props) {
         </div>
       )}
 
+      {/* PlaneSunViz */}
+      {rec.samples && rec.samples.length > 0 && (
+        <PlaneSunViz samples={rec.samples} />
+      )}
+
       {/* Actions */}
       <div className="mt-3 flex items-center gap-3 flex-wrap">
         <button
           onClick={copy}
           className="text-sm underline"
           aria-live="polite"
-          aria-label="Copy result"
+          aria-label="Copy recommendation"
         >
-          {copied ? "Copied!" : "Copy result"}
+          {copied ? "Copied!" : "Copy recommendation"}
         </button>
         <span
           className={`text-xs rounded-full px-2 py-1 transition-opacity duration-200 ${

--- a/components/SunSparkline.tsx
+++ b/components/SunSparkline.tsx
@@ -74,7 +74,7 @@ export default function SunSparkline({ samples, height = 100 }: Props) {
       fullPath,
       sunPath,
     };
-  }, [samples, height]);
+  }, [samples, height, paddingTop]);
 
   if (!model) return null;
 

--- a/lib/geo.ts
+++ b/lib/geo.ts
@@ -6,7 +6,7 @@ const toDeg = (r: number) => (r * 180) / Math.PI;
 
 /** Normalize angle to (-180, 180] */
 export const wrapTo180 = (x: number) => {
-  let a = (((x + 180) % 360) + 360) % 360; // 0..360
+  const a = (((x + 180) % 360) + 360) % 360; // 0..360
   return a > 180 ? a - 360 : a;
 };
 

--- a/lib/logic.ts
+++ b/lib/logic.ts
@@ -16,7 +16,6 @@ export function computeRecommendation(params: {
   const {
     origin,
     dest,
-    departLocalISO,
     preference,
     sampleMinutes = 5,
   } = params;
@@ -35,11 +34,13 @@ export function computeRecommendation(params: {
   let peakAltitudeDeg = -90;
   let sunriseUTC: string | undefined;
   let sunsetUTC: string | undefined;
+  let sunriseSampleIndex: number | undefined;
+  let sunsetSampleIndex: number | undefined;
   const samples: Sample[] = [];
 
   let wasEffective = false;
 
-  for (let elapsed = 0; elapsed <= totalMinutes; elapsed += sampleMinutes) {
+  for (let elapsed = 0, idx = 0; elapsed <= totalMinutes; elapsed += sampleMinutes, idx++) {
     const frac = elapsed / totalMinutes;
     const pos = intermediatePoint(origin, dest, frac);
     const course = trackAt(origin, dest, frac);
@@ -57,11 +58,13 @@ export function computeRecommendation(params: {
 
       if (!wasEffective) {
         sunriseUTC = ts.toISOString();
+        sunriseSampleIndex = idx;
         wasEffective = true;
       }
     } else {
       if (wasEffective) {
         sunsetUTC = ts.toISOString();
+        sunsetSampleIndex = idx;
         wasEffective = false;
       }
     }
@@ -100,6 +103,10 @@ export function computeRecommendation(params: {
     peakAltitudeDeg: Math.round(peakAltitudeDeg * 10) / 10,
     sunriseUTC,
     sunsetUTC,
+    sunriseSampleIndex,
+    sunsetSampleIndex,
+    sunriseCity: sunriseUTC ? origin.name : undefined,
+    sunsetCity: sunsetUTC ? dest.name : undefined,
     confidence: Math.round(confidence * 100) / 100,
     samples,
   };

--- a/lib/plane.ts
+++ b/lib/plane.ts
@@ -1,0 +1,34 @@
+import { wrapTo180 } from "./geo";
+
+export type SunPlaneRelation = {
+  /** relative azimuth of sun from aircraft nose, degrees (-180..180) */
+  relAz: number;
+  /** which side of aircraft receives sun */
+  side: "A" | "F" | "none";
+  /** glare intensity 0..1 based on altitude */
+  intensity: number;
+};
+
+/**
+ * Determine sun side and glare intensity relative to aircraft course.
+ * @param az Sun azimuth in degrees (0..360 from north)
+ * @param course Aircraft course/bearing in degrees (0..360 from north)
+ * @param alt Sun altitude in degrees
+ */
+export function sunPlaneRelation(
+  az: number,
+  course: number,
+  alt: number
+): SunPlaneRelation {
+  const rel = wrapTo180(az - course);
+  const intensity = Math.max(0, Math.min(1, alt / 90));
+  let side: "A" | "F" | "none" = "none";
+  if (alt >= 5) {
+    const absRel = Math.abs(rel);
+    if (absRel >= 20 && absRel <= 160) {
+      side = rel > 0 ? "F" : "A";
+    }
+  }
+  return { relAz: rel, side, intensity };
+}
+

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -25,6 +25,10 @@ export type Recommendation = {
   peakAltitudeDeg: number;
   sunriseUTC?: string;
   sunsetUTC?: string;
+  sunriseSampleIndex?: number;
+  sunsetSampleIndex?: number;
+  sunriseCity?: string;
+  sunsetCity?: string;
   confidence: number; // 0..1
   samples: Sample[];
 };

--- a/tests/logic.test.ts
+++ b/tests/logic.test.ts
@@ -29,4 +29,8 @@ test("DEL to DXB evening — should produce a side and not crash", () => {
   expect(rec.leftMinutes).toBeTypeOf("number");
   expect(rec.rightMinutes).toBeTypeOf("number");
   expect(rec.samples.length).toBeGreaterThan(0);
+  expect(rec).toHaveProperty("sunriseSampleIndex");
+  expect(rec).toHaveProperty("sunsetSampleIndex");
+  expect(rec).toHaveProperty("sunriseCity");
+  expect(rec).toHaveProperty("sunsetCity");
 });

--- a/tests/plane.test.ts
+++ b/tests/plane.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { sunPlaneRelation } from "../lib/plane";
+
+describe("sunPlaneRelation", () => {
+  it("identifies sun on right (F)", () => {
+    const r = sunPlaneRelation(270, 0, 10); // sun west relative to northbound plane
+    expect(r.side).toBe("F");
+  });
+
+  it("identifies sun on left (A)", () => {
+    const r = sunPlaneRelation(90, 0, 10); // sun east relative to northbound plane
+    expect(r.side).toBe("A");
+  });
+
+  it("returns none when sun below horizon", () => {
+    const r = sunPlaneRelation(90, 0, 0);
+    expect(r.side).toBe("none");
+    expect(r.intensity).toBe(0);
+  });
+
+  it("returns none when sun ahead", () => {
+    const r = sunPlaneRelation(0, 0, 10); // sun straight ahead
+    expect(r.side).toBe("none");
+  });
+
+  it("returns none when sun behind", () => {
+    const r = sunPlaneRelation(180, 0, 10); // sun directly behind
+    expect(r.side).toBe("none");
+  });
+
+  it("scales intensity by altitude", () => {
+    const r = sunPlaneRelation(90, 0, 45);
+    expect(r.intensity).toBeCloseTo(0.5, 5);
+  });
+});


### PR DESCRIPTION
## Summary
- Introduced an interactive PlaneSunViz that visualizes sun position and glare along the flight path
- Added sunPlaneRelation helper and wired PlaneSunViz into the result card
- Restored sunrise/sunset sample index and city fields in Recommendation and computeRecommendation
- Expanded unit test to assert presence of the restored metadata

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689858c41a4083338178b88ef393bb1b