### PR TITLE
fix: remove unused dest prop

### DIFF
--- a/components/CompareCard.tsx
+++ b/components/CompareCard.tsx
@@ -54,7 +54,6 @@ type Props = {
 export default function CompareCard({
   rec,
   origin,
-  dest,
   thresholdKm,
   onThresholdChange,
   // progress,


### PR DESCRIPTION
## Summary
- remove unused `dest` prop from `CompareCard`

## Testing
- `npx eslint .`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689886cba0a48333ae0d60ada3342cef