### PR TITLE
Align sun events with real locales and sync map plane icon

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -38,7 +38,7 @@ export default function Home() {
 
   // Comparison controls
   const [thresholdKm, setThresholdKm] = useState<number>(75);
-  const [progress, setProgress] = useState<number>(0);
+  const [sampleIndex, setSampleIndex] = useState<number>(0);
 
   const cityPassBys: PassBy[] = useMemo(() => {
     if (!rec?.samples?.length) return [];
@@ -83,7 +83,7 @@ export default function Home() {
     setRec(null);
     setOrigin(undefined);
     setDest(undefined);
-    setProgress(0);
+    setSampleIndex(0);
     setThresholdKm(75);
     router.replace("/");
   }
@@ -113,13 +113,18 @@ export default function Home() {
             dest={dest}
             thresholdKm={thresholdKm}
             onThresholdChange={(v) => setThresholdKm(v)}
-            progress={progress}
-            onProgressChange={(p) => setProgress(p)}
             passBys={cityPassBys}
           />
         )}
 
-        <ResultCard rec={rec} origin={origin} dest={dest} preference={pref} />
+        <ResultCard
+          rec={rec}
+          origin={origin}
+          dest={dest}
+          preference={pref}
+          sampleIndex={sampleIndex}
+          onSampleIndexChange={setSampleIndex}
+        />
 
         <MapView
           samples={rec?.samples ?? null}
@@ -129,6 +134,7 @@ export default function Home() {
           sunsetIndex={rec?.sunsetSampleIndex}
           sunriseCity={rec?.sunriseCity}
           sunsetCity={rec?.sunsetCity}
+          planeIndex={sampleIndex}
         />
 
         <footer className="text-xs text-zinc-500 dark:text-zinc-400 pt-2">

--- a/components/CompareCard.tsx
+++ b/components/CompareCard.tsx
@@ -147,6 +147,21 @@ export default function CompareCard({
         </div>
       </div>
 
+      {((!rec.sunriseSide && rec.sunriseUTC) || (!rec.sunsetSide && rec.sunsetUTC)) && (
+        <div className="mb-3 flex flex-wrap gap-2">
+          {!rec.sunriseSide && rec.sunriseUTC && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200 px-3 py-1 text-xs">
+              🌅 Sunrise visible both sides
+            </span>
+          )}
+          {!rec.sunsetSide && rec.sunsetUTC && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-pink-100 text-pink-800 dark:bg-pink-900/40 dark:text-pink-200 px-3 py-1 text-xs">
+              🌇 Sunset visible both sides
+            </span>
+          )}
+        </div>
+      )}
+
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div className="rounded-xl p-4 bg-gradient-to-br from-zinc-50 to-white dark:from-zinc-900 dark:to-zinc-800 border border-zinc-200 dark:border-zinc-700">
           <h3 className="text-lg font-bold mb-2">A (left)</h3>

--- a/components/MapView.tsx
+++ b/components/MapView.tsx
@@ -24,6 +24,7 @@ type Props = {
   sunsetIndex?: number;
   sunriseCity?: string;
   sunsetCity?: string;
+  planeIndex?: number;
 };
 
 const FitBounds = ({ samples }: { samples: Sample[] }) => {
@@ -37,7 +38,7 @@ const FitBounds = ({ samples }: { samples: Sample[] }) => {
   return null;
 };
 
-export default function MapView({ samples, cities = [], thresholdKm = 75, sunriseIndex, sunsetIndex, sunriseCity, sunsetCity }: Props) {
+export default function MapView({ samples, cities = [], thresholdKm = 75, sunriseIndex, sunsetIndex, sunriseCity, sunsetCity, planeIndex }: Props) {
   const [legendOpen, setLegendOpen] = useState(true);
   if (!samples || samples.length < 2) return null;
 
@@ -46,6 +47,8 @@ export default function MapView({ samples, cities = [], thresholdKm = 75, sunris
   const sunsetSample = sunsetIndex !== undefined ? samples[sunsetIndex] : null;
   const sunriseIcon = L.divIcon({ className: "", html: "🌅", iconSize: [20, 20], iconAnchor: [10, 10] });
   const sunsetIcon = L.divIcon({ className: "", html: "🌇", iconSize: [20, 20], iconAnchor: [10, 10] });
+  const planeSample = planeIndex !== undefined ? samples[Math.min(planeIndex, samples.length - 1)] : null;
+  const planeIcon = L.divIcon({ className: "opacity-60", html: "✈️", iconSize: [20, 20], iconAnchor: [10, 10] });
 
   function cityStyle(side: "A" | "F", dist: number) {
     const t = Math.max(10, thresholdKm);
@@ -99,6 +102,11 @@ export default function MapView({ samples, cities = [], thresholdKm = 75, sunris
               </CircleMarker>
             );
           })}
+        </Pane>
+
+        {/* plane marker */}
+        <Pane name="plane-marker" style={{ zIndex: 650 }}>
+          {planeSample && <Marker position={[planeSample.lat, planeSample.lon]} icon={planeIcon} opacity={0.6} />}
         </Pane>
 
         {/* sun markers (top) */}

--- a/components/PlaneSunViz.tsx
+++ b/components/PlaneSunViz.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, type CSSProperties } from "react";
+import { useRef, useEffect, useState, type CSSProperties } from "react";
 import type { Sample } from "@/lib/types";
 import { sunPlaneRelation } from "@/lib/plane";
 import { formatLocal } from "@/lib/time";
@@ -11,11 +11,21 @@ interface Props {
   samples: Sample[] | null;
   sunriseIndex?: number;
   sunsetIndex?: number;
-  tz?: string;
+  index: number;
+  onIndexChange: (i: number) => void;
+  sunriseTz?: string;
+  sunsetTz?: string;
 }
 
-export default function PlaneSunViz({ samples, sunriseIndex, sunsetIndex, tz }: Props) {
-  const [index, setIndex] = useState(0);
+export default function PlaneSunViz({
+  samples,
+  sunriseIndex,
+  sunsetIndex,
+  index,
+  onIndexChange,
+  sunriseTz,
+  sunsetTz,
+}: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(0);
 
@@ -57,12 +67,12 @@ export default function PlaneSunViz({ samples, sunriseIndex, sunsetIndex, tz }: 
       ? (sunsetIndex / (samples.length - 1)) * 100
       : null;
   const sunriseTime =
-    sunriseIndex !== undefined && tz
-      ? formatLocal(new Date(samples[sunriseIndex].utc), tz, "HH:mm")
+    sunriseIndex !== undefined && sunriseTz
+      ? formatLocal(new Date(samples[sunriseIndex].utc), sunriseTz, "HH:mm")
       : null;
   const sunsetTime =
-    sunsetIndex !== undefined && tz
-      ? formatLocal(new Date(samples[sunsetIndex].utc), tz, "HH:mm")
+    sunsetIndex !== undefined && sunsetTz
+      ? formatLocal(new Date(samples[sunsetIndex].utc), sunsetTz, "HH:mm")
       : null;
 
   return (
@@ -125,7 +135,7 @@ export default function PlaneSunViz({ samples, sunriseIndex, sunsetIndex, tz }: 
             min={0}
             max={samples.length - 1}
             value={idx}
-            onChange={(e) => setIndex(Number(e.target.value))}
+            onChange={(e) => onIndexChange(Number(e.target.value))}
             aria-label="Time along flight"
             className={`w-full cursor-pointer ${sliderStyles.range}`}
             style={{ "--progress": `${(idx / (samples.length - 1)) * 100}%` } as CSSProperties}

--- a/components/SunSparkline.tsx
+++ b/components/SunSparkline.tsx
@@ -2,10 +2,11 @@
 
 import type { Sample } from "@/lib/types";
 import { useMemo } from "react";
+import { formatLocal } from "@/lib/time";
 
-type Props = { samples: Sample[]; height?: number };
+type Props = { samples: Sample[]; height?: number; tz?: string };
 
-export default function SunSparkline({ samples, height = 100 }: Props) {
+export default function SunSparkline({ samples, height = 80, tz }: Props) {
   // Reserve space on top for the legend so the path never overlaps it
   const LEGEND_SPACE = 34;
   const width = 560;
@@ -90,6 +91,7 @@ export default function SunSparkline({ samples, height = 100 }: Props) {
   } = model;
 
   return (
+    <>
     <svg
       viewBox={`0 0 ${W} ${H}`}
       width="100%"
@@ -129,12 +131,12 @@ export default function SunSparkline({ samples, height = 100 }: Props) {
         fill="none"
         stroke="currentColor"
         opacity="0.35"
-        strokeWidth={3}
+        strokeWidth={2}
       />
 
       {/* Sun-visible segment (highlighted) */}
       {sunPath && (
-        <path d={sunPath} fill="none" stroke="url(#spark)" strokeWidth={3} />
+        <path d={sunPath} fill="none" stroke="url(#spark)" strokeWidth={2} />
       )}
 
       {/* Markers */}
@@ -232,5 +234,14 @@ export default function SunSparkline({ samples, height = 100 }: Props) {
         </text>
       </g>
     </svg>
+    <div className="mt-1 flex justify-between text-[10px] text-zinc-500 dark:text-zinc-400">
+      <span>{tz ? formatLocal(new Date(samples[0].utc), tz, "HH:mm") : formatLocal(new Date(samples[0].utc), "UTC", "HH:mm")}</span>
+      <span>
+        {tz
+          ? formatLocal(new Date(samples[samples.length - 1].utc), tz, "HH:mm")
+          : formatLocal(new Date(samples[samples.length - 1].utc), "UTC", "HH:mm")}
+      </span>
+    </div>
+    </>
   );
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -27,10 +27,12 @@ export type Recommendation = {
   sunriseSide?: "A" | "F";
   sunriseSampleIndex?: number;
   sunriseCity?: string;
+  sunriseTz?: string;
   sunsetUTC?: string;
   sunsetSide?: "A" | "F";
   sunsetSampleIndex?: number;
   sunsetCity?: string;
+  sunsetTz?: string;
   confidence: number; // 0..1
   samples: Sample[];
 };


### PR DESCRIPTION
## Summary
- capture sunrise and sunset timezone from nearest city for consistent event times
- show premium sunrise/sunset pills when visible from both sides
- sync time scrubber with a moving plane marker on the map and slim sun sparkline with time axis

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68988d0527c88333ad989d1f39236956