### PR TITLE
Enhance sun event details and adjust map marker opacity

### DIFF
--- a/components/CompareCard.tsx
+++ b/components/CompareCard.tsx
@@ -5,6 +5,7 @@ import type { Recommendation, Airport } from "@/lib/types";
 import { sortPassBys, type PassBy, type SortMode } from "@/lib/cities";
 import Slider from "@/components/ui/Slider";
 import { formatLocal } from "@/lib/time";
+import { firstSunIndex, lastSunIndex, sampleLocalHM } from "@/lib/logic";
 
 function Stat({ label, value, sub }: { label: string; value: string; sub?: string }) {
   return (
@@ -82,6 +83,18 @@ export default function CompareCard({
   const leftPct = totalEff ? Math.round((rec.leftMinutes / totalEff) * 100) : 0;
   const rightPct = totalEff ? Math.round((rec.rightMinutes / totalEff) * 100) : 0;
 
+  const sunriseIdx = firstSunIndex(rec.samples);
+  const sunsetIdx = lastSunIndex(rec.samples);
+  const sunriseNote =
+    sunriseIdx !== null && origin?.tz && ["A", "F"].includes(rec.samples[sunriseIdx].side)
+      ? `Sunrise ~${sampleLocalHM(rec.samples, sunriseIdx, origin.tz)} on ${rec.samples[sunriseIdx].side} (${rec.samples[sunriseIdx].side === "A" ? "left" : "right"})`
+      : null;
+  const sunsetNote =
+    sunsetIdx !== null && origin?.tz && ["A", "F"].includes(rec.samples[sunsetIdx].side)
+      ? `Sunset ~${sampleLocalHM(rec.samples, sunsetIdx, origin.tz)} on ${rec.samples[sunsetIdx].side} (${rec.samples[sunsetIdx].side === "A" ? "left" : "right"})`
+      : null;
+  const visNote = [sunriseNote, sunsetNote].filter(Boolean).join(" • ");
+
   return (
     <div className="relative p-5 bg-white dark:bg-zinc-800 rounded-2xl shadow border border-zinc-200 dark:border-zinc-700">
       {/* Header row: left (pill + sort), right (threshold only) */}
@@ -146,6 +159,10 @@ export default function CompareCard({
           {/* Time scrubber hidden for now to keep the map uncluttered */}
         </div>
       </div>
+
+      <p className="mb-3 text-sm text-zinc-600 dark:text-zinc-400">
+        Sun exposure — left {leftPct}% • right {rightPct}%{visNote ? ` • ${visNote}` : ""}
+      </p>
 
       {((!rec.sunriseSide && rec.sunriseUTC) || (!rec.sunsetSide && rec.sunsetUTC)) && (
         <div className="mb-3 flex flex-wrap gap-2">

--- a/components/MapView.tsx
+++ b/components/MapView.tsx
@@ -48,7 +48,7 @@ export default function MapView({ samples, cities = [], thresholdKm = 75, sunris
   const sunriseIcon = L.divIcon({ className: "", html: "🌅", iconSize: [20, 20], iconAnchor: [10, 10] });
   const sunsetIcon = L.divIcon({ className: "", html: "🌇", iconSize: [20, 20], iconAnchor: [10, 10] });
   const planeSample = planeIndex !== undefined ? samples[Math.min(planeIndex, samples.length - 1)] : null;
-  const planeIcon = L.divIcon({ className: "opacity-60", html: "✈️", iconSize: [20, 20], iconAnchor: [10, 10] });
+  const planeIcon = L.divIcon({ className: "opacity-90", html: "✈️", iconSize: [20, 20], iconAnchor: [10, 10] });
 
   function cityStyle(side: "A" | "F", dist: number) {
     const t = Math.max(10, thresholdKm);
@@ -106,7 +106,7 @@ export default function MapView({ samples, cities = [], thresholdKm = 75, sunris
 
         {/* plane marker */}
         <Pane name="plane-marker" style={{ zIndex: 650 }}>
-          {planeSample && <Marker position={[planeSample.lat, planeSample.lon]} icon={planeIcon} opacity={0.6} />}
+          {planeSample && <Marker position={[planeSample.lat, planeSample.lon]} icon={planeIcon} opacity={0.9} />}
         </Pane>
 
         {/* sun markers (top) */}

--- a/components/SunSparkline.tsx
+++ b/components/SunSparkline.tsx
@@ -20,7 +20,6 @@ export default function SunSparkline({ samples, height = 80, tz }: Props) {
     const xs = samples.map((_, i) => i);
     const ys = samples.map((s) => s.alt);
 
-    const xMin = 0;
     const xMax = Math.max(1, samples.length - 1);
     // pad y-range a bit to avoid clipping at edges
     const yMin = Math.min(-10, Math.min(...ys)) - 1;
@@ -29,8 +28,7 @@ export default function SunSparkline({ samples, height = 80, tz }: Props) {
     const innerW = width - paddingX * 2;
     const innerH = height - paddingTop - paddingBottom;
 
-    const xScale = (i: number) =>
-      paddingX + ((i - xMin) / (xMax - xMin)) * innerW;
+    const xScale = (i: number) => paddingX + (i / xMax) * innerW;
 
     // y grows downward → invert for altitude
     const yScale = (v: number) =>
@@ -235,12 +233,8 @@ export default function SunSparkline({ samples, height = 80, tz }: Props) {
       </g>
     </svg>
     <div className="mt-1 flex justify-between text-[10px] text-zinc-500 dark:text-zinc-400">
-      <span>{tz ? formatLocal(new Date(samples[0].utc), tz, "HH:mm") : formatLocal(new Date(samples[0].utc), "UTC", "HH:mm")}</span>
-      <span>
-        {tz
-          ? formatLocal(new Date(samples[samples.length - 1].utc), tz, "HH:mm")
-          : formatLocal(new Date(samples[samples.length - 1].utc), "UTC", "HH:mm")}
-      </span>
+      <span>{formatLocal(new Date(samples[0].utc), tz ?? "UTC", "HH:mm")}</span>
+      <span>{formatLocal(new Date(samples[samples.length - 1].utc), tz ?? "UTC", "HH:mm")}</span>
     </div>
     </>
   );

--- a/lib/logic.ts
+++ b/lib/logic.ts
@@ -1,6 +1,6 @@
 import { Airport, Preference, Recommendation, Sample } from "./types";
 import { gcDistanceKm, intermediatePoint, trackAt, wrapTo180 } from "./geo";
-import { addMinutes, localISOToUTCDate } from "./time";
+import { addMinutes, localISOToUTCDate, formatLocal } from "./time";
 import { sunAt, isSunEffective } from "./sun";
 import cities from "./cities.json";
 import type { City } from "./cities";
@@ -144,5 +144,26 @@ export function computeRecommendation(params: {
     confidence: Math.round(confidence * 100) / 100,
     samples,
   };
+}
+
+/** Index of the first sample where the sun is above the horizon. */
+export function firstSunIndex(samples: Sample[]): number | null {
+  for (let i = 0; i < samples.length; i++) if (samples[i].alt > 0) return i;
+  return null;
+}
+
+/** Index of the last sample where the sun is above the horizon. */
+export function lastSunIndex(samples: Sample[]): number | null {
+  for (let i = samples.length - 1; i >= 0; i--) if (samples[i].alt > 0) return i;
+  return null;
+}
+
+/**
+ * Format a sample's UTC time into local time of a reference zone.
+ * Returns null when index is out of bounds.
+ */
+export function sampleLocalHM(samples: Sample[], idx: number, tz: string): string | null {
+  if (idx == null || idx < 0 || idx >= samples.length) return null;
+  return formatLocal(new Date(samples[idx].utc), tz, "HH:mm");
 }
 


### PR DESCRIPTION
## Summary
- Increase airplane marker opacity on map for better visibility
- Add utilities for first/last sun indices and local time formatting
- Surface sunrise and sunset times with seat side context in result and comparison cards
- Correct sun sparkline scale and axis labels

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6898927716c48333bb8dcd459cf5b46d