### PR TITLE
Enhance sun visualization and sunrise handling

### DIFF
--- a/components/MapView.tsx
+++ b/components/MapView.tsx
@@ -48,7 +48,12 @@ export default function MapView({ samples, cities = [], thresholdKm = 75, sunris
   const sunriseIcon = L.divIcon({ className: "", html: "🌅", iconSize: [20, 20], iconAnchor: [10, 10] });
   const sunsetIcon = L.divIcon({ className: "", html: "🌇", iconSize: [20, 20], iconAnchor: [10, 10] });
   const planeSample = planeIndex !== undefined ? samples[Math.min(planeIndex, samples.length - 1)] : null;
-  const planeIcon = L.divIcon({ className: "opacity-90", html: "✈️", iconSize: [20, 20], iconAnchor: [10, 10] });
+  const planeIcon = L.divIcon({
+    className: "opacity-90",
+    html: "<span style='font-size:24px'>✈️</span>",
+    iconSize: [32, 32],
+    iconAnchor: [16, 16],
+  });
 
   function cityStyle(side: "A" | "F", dist: number) {
     const t = Math.max(10, thresholdKm);

--- a/components/SunSparkline.tsx
+++ b/components/SunSparkline.tsx
@@ -75,6 +75,17 @@ export default function SunSparkline({ samples, height = 80, tz }: Props) {
     };
   }, [samples, height, paddingTop]);
 
+  const tickTimes = useMemo(() => {
+    if (!samples.length) return [];
+    const start = new Date(samples[0].utc);
+    const end = new Date(samples[samples.length - 1].utc);
+    const intervals = 4;
+    const delta = end.getTime() - start.getTime();
+    return Array.from({ length: intervals + 1 }, (_, i) =>
+      formatLocal(new Date(start.getTime() + (delta * i) / intervals), tz ?? "UTC", "HH:mm"),
+    );
+  }, [samples, tz]);
+
   if (!model) return null;
 
   const {
@@ -233,8 +244,9 @@ export default function SunSparkline({ samples, height = 80, tz }: Props) {
       </g>
     </svg>
     <div className="mt-1 flex justify-between text-[10px] text-zinc-500 dark:text-zinc-400">
-      <span>{formatLocal(new Date(samples[0].utc), tz ?? "UTC", "HH:mm")}</span>
-      <span>{formatLocal(new Date(samples[samples.length - 1].utc), tz ?? "UTC", "HH:mm")}</span>
+      {tickTimes.map((t, i) => (
+        <span key={i}>{t}</span>
+      ))}
     </div>
     </>
   );

--- a/lib/logic.ts
+++ b/lib/logic.ts
@@ -73,12 +73,18 @@ export function computeRecommendation(params: {
     }
 
     if (!wasEffective && effective) {
-      sunriseUTC = ts.toISOString();
       sunriseSide = side === "A" || side === "F" ? side : undefined;
-      sunriseSampleIndex = idx;
       const city = nearestCity(pos.lat, pos.lon);
       sunriseCity = city?.name;
       sunriseTz = city?.tz;
+      if (idx === 0) {
+        // Sun already above horizon at departure – record synthetic time before takeoff
+        sunriseUTC = addMinutes(ts, -sampleMinutes).toISOString();
+        sunriseSampleIndex = undefined;
+      } else {
+        sunriseUTC = ts.toISOString();
+        sunriseSampleIndex = idx;
+      }
     }
 
     if (wasEffective && !effective) {


### PR DESCRIPTION
## Summary
- Expand sun sparkline timeline with evenly spaced time labels
- Enlarge airplane marker on the map for better visibility
- Treat pre-departure sunlight as synthetic sunrise to avoid markers at takeoff

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689897c130688333a9b95c3d5184fa7b