### PR TITLE
Expand city and airport datasets

### DIFF
--- a/lib/airports.json
+++ b/lib/airports.json
@@ -3834,5 +3834,19 @@
     "lat": 46.161388,
     "lon": -60.047779,
     "tz": "America/Glace_Bay"
+  },
+  {
+    "iata": "VKO",
+    "name": "Vnukovo International Airport",
+    "lat": 55.5915,
+    "lon": 37.2615,
+    "tz": "Europe/Moscow"
+  },
+  {
+    "iata": "KBP",
+    "name": "Boryspil International Airport",
+    "lat": 50.345,
+    "lon": 30.8947,
+    "tz": "Europe/Kyiv"
   }
 ]

--- a/lib/cities.json
+++ b/lib/cities.json
@@ -435,5 +435,19 @@
     "lat": -19.9167,
     "lon": -43.9345,
     "tz": "America/Sao_Paulo"
+  },
+  { "name": "Moscow", "lat": 55.7558, "lon": 37.6173, "tz": "Europe/Moscow" },
+  {
+    "name": "Saint Petersburg",
+    "lat": 59.9311,
+    "lon": 30.3609,
+    "tz": "Europe/Moscow"
+  },
+  { "name": "Kyiv", "lat": 50.4501, "lon": 30.5234, "tz": "Europe/Kyiv" },
+  {
+    "name": "Havana",
+    "lat": 23.1136,
+    "lon": -82.3666,
+    "tz": "America/Havana"
   }
 ]


### PR DESCRIPTION
## Summary
- add major cities like Moscow, Saint Petersburg, Kyiv and Havana
- include Vnukovo (VKO) and Boryspil (KBP) airports

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68989fe1a7688333bb3b3f0dbddfcd77