### PR TITLE
fix: handle null IATA inputs

### DIFF
--- a/components/Inputs.tsx
+++ b/components/Inputs.tsx
@@ -180,7 +180,7 @@ export default function Inputs({ onSubmit, defaults, loading = false, onClearAll
           label="From (IATA)"
           placeholder="e.g., JFK"
           value={from}
-          onChange={(v) => setFrom(v.toUpperCase())}
+          onChange={(v) => setFrom(v ? v.toUpperCase() : "")}
           airports={airports}
           inputRef={fromRef}
         />
@@ -197,7 +197,7 @@ export default function Inputs({ onSubmit, defaults, loading = false, onClearAll
           label="To (IATA)"
           placeholder="e.g., LHR"
           value={to}
-          onChange={(v) => setTo(v.toUpperCase())}
+          onChange={(v) => setTo(v ? v.toUpperCase() : "")}
           airports={airports}
         />
       </div>


### PR DESCRIPTION
## Summary
- ensure IATA input handlers guard against null values to avoid toUpperCase errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898a21d6c308333b944716f28467cb1