### PR TITLE
Ensure map renders when sun unseen

### DIFF
--- a/lib/logic.ts
+++ b/lib/logic.ts
@@ -69,7 +69,10 @@ export function computeRecommendation(params: {
   let wasEffective = false;
   let currentSide: "A" | "F" | undefined;
 
-  for (let elapsed = 0, idx = 0; elapsed <= totalMinutes; elapsed += sampleMinutes, idx++) {
+  // Always include the final destination sample even for very short flights
+  const sampleCount = Math.ceil(totalMinutes / sampleMinutes) + 1;
+  for (let idx = 0; idx < sampleCount; idx++) {
+    const elapsed = Math.min(totalMinutes, idx * sampleMinutes);
     const frac = elapsed / totalMinutes;
     const pos = intermediatePoint(origin, dest, frac);
     const course = trackAt(origin, dest, frac);

--- a/tests/logic.test.ts
+++ b/tests/logic.test.ts
@@ -100,3 +100,18 @@ test("custom arrival overrides duration", () => {
   });
   expect(rec.samples.length).toBe(25);
 });
+
+test("generates at least two samples for very short flights", () => {
+  const rec = computeRecommendation({
+    origin: DEL,
+    dest: DXB,
+    departLocalISO: "2025-08-10T18:30",
+    arriveLocalISO: "2025-08-10T18:31", // 1-minute duration
+    preference: "see",
+    sampleMinutes: 5,
+  });
+  expect(rec.samples.length).toBeGreaterThan(1);
+  const last = rec.samples.at(-1)!;
+  expect(last.lat).toBeCloseTo(DXB.lat, 3);
+  expect(last.lon).toBeCloseTo(DXB.lon, 3);
+});


### PR DESCRIPTION
## Summary
- ensure sampling always includes destination point so maps render even when the sun stays below the horizon
- add regression test for very short flights

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898ab86563c833396bec44a933a314a