### PR TITLE
feat: expand city list and tweak sun markers

### DIFF
--- a/components/Inputs.tsx
+++ b/components/Inputs.tsx
@@ -5,13 +5,7 @@ import airportsData from "@/lib/airports.json";
 import type { Airport, Preference } from "@/lib/types";
 import IataCombo from "@/components/IataCombo";
 import { ArrowsRightLeftIcon } from "@heroicons/react/24/outline";
-import {
-  addMinutes,
-  convertLocalISO,
-  formatLocal,
-  localISOToUTCDate,
-} from "@/lib/time";
-import { estimateDurationMinutes } from "@/lib/logic";
+import { convertLocalISO } from "@/lib/time";
 import TimezoneSelect from "@/components/TimezoneSelect";
 import PreferenceToggle from "@/components/PreferenceToggle";
 import DateTime24 from "@/components/DateTime24";
@@ -41,7 +35,6 @@ export default function Inputs({ onSubmit, defaults, loading = false, onClearAll
   const [to, setTo] = useState(defaults?.to ?? "");
   const [depart, setDepart] = useState(defaults?.depart ?? "");
   const [arrive, setArrive] = useState(defaults?.arrive ?? "");
-  const [arriveEdited, setArriveEdited] = useState(!!defaults?.arrive);
   const [tzMode, setTzMode] = useState<TZMode>("origin");
   const [customTZ, setCustomTZ] = useState<string | null>(null);
   const [pref, setPref] = useState<Preference>("see");
@@ -95,31 +88,6 @@ export default function Inputs({ onSubmit, defaults, loading = false, onClearAll
       ? destAirport?.tz ?? "—"
       : customTZ || "—";
 
-  // Auto-compute arrival whenever inputs change
-  useEffect(() => {
-    if (arriveEdited) return;
-    if (!depart || !originAirport || !destAirport) {
-      setArrive("");
-      return;
-    }
-    const departTZ =
-      tzMode === "origin"
-        ? originAirport.tz
-        : tzMode === "dest"
-        ? destAirport.tz
-        : customTZ || originAirport.tz;
-    const depUTC = localISOToUTCDate(depart, departTZ);
-    const arrUTC = addMinutes(
-      depUTC,
-      estimateDurationMinutes(originAirport, destAirport)
-    );
-    const arrLocal = formatLocal(
-      arrUTC,
-      destAirport.tz,
-      "yyyy-LL-dd'T'HH:mm"
-    );
-    setArrive(arrLocal);
-  }, [depart, originAirport, destAirport, tzMode, customTZ, arriveEdited]);
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -154,7 +122,6 @@ export default function Inputs({ onSubmit, defaults, loading = false, onClearAll
     setTo("");
     setDepart("");
     setArrive("");
-    setArriveEdited(false);
     setError(null);
     try { localStorage.removeItem("ss_recent"); } catch {}
     setRecent([]);
@@ -166,7 +133,6 @@ export default function Inputs({ onSubmit, defaults, loading = false, onClearAll
     setFrom(to);
     setTo(old);
     setTzMode((m) => (m === "origin" ? "dest" : m === "dest" ? "origin" : "custom"));
-    setArriveEdited(false);
   }
 
   function applyPreset(a: string, b: string, h = 7, m = 0) {
@@ -181,7 +147,6 @@ export default function Inputs({ onSubmit, defaults, loading = false, onClearAll
       .slice(0, 16);
     setDepart(iso);
     setArrive("");
-    setArriveEdited(false);
   }
 
   const chipKey = (onActivate: () => void) => (e: React.KeyboardEvent) => {
@@ -204,7 +169,7 @@ export default function Inputs({ onSubmit, defaults, loading = false, onClearAll
             value={from}
             onChange={(v) => {
               setFrom(v ? v.toUpperCase() : "");
-              setArriveEdited(false);
+              
             }}
             airports={airports}
             inputRef={fromRef}
@@ -224,7 +189,7 @@ export default function Inputs({ onSubmit, defaults, loading = false, onClearAll
             value={to}
             onChange={(v) => {
               setTo(v ? v.toUpperCase() : "");
-              setArriveEdited(false);
+              
             }}
             airports={airports}
           />
@@ -243,7 +208,7 @@ export default function Inputs({ onSubmit, defaults, loading = false, onClearAll
               value={depart}
               onChange={(v) => {
                 setDepart(v);
-                setArriveEdited(false);
+                
               }}
             />
           </div>
@@ -259,7 +224,7 @@ export default function Inputs({ onSubmit, defaults, loading = false, onClearAll
               value={arrive}
               onChange={(v) => {
                 setArrive(v);
-                setArriveEdited(true);
+                
               }}
             />
           </div>

--- a/components/PlaneSunViz.tsx
+++ b/components/PlaneSunViz.tsx
@@ -3,29 +3,15 @@
 import { useRef, useEffect, useState, type CSSProperties } from "react";
 import type { Sample } from "@/lib/types";
 import { sunPlaneRelation } from "@/lib/plane";
-import { formatLocal } from "@/lib/time";
-import SunEventMarker from "@/components/SunEventMarker";
 import sliderStyles from "./ui/slider.module.css";
 
 interface Props {
   samples: Sample[] | null;
-  sunriseIndex?: number;
-  sunsetIndex?: number;
   index: number;
   onIndexChange: (i: number) => void;
-  sunriseTz?: string;
-  sunsetTz?: string;
 }
 
-export default function PlaneSunViz({
-  samples,
-  sunriseIndex,
-  sunsetIndex,
-  index,
-  onIndexChange,
-  sunriseTz,
-  sunsetTz,
-}: Props) {
+export default function PlaneSunViz({ samples, index, onIndexChange }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(0);
 
@@ -58,22 +44,6 @@ export default function PlaneSunViz({
   const leftOpacity = rel.side === "A" ? rel.intensity : 0;
   const rightOpacity = rel.side === "F" ? rel.intensity : 0;
 
-  const sunrisePct =
-    sunriseIndex !== undefined && samples.length > 1
-      ? (sunriseIndex / (samples.length - 1)) * 100
-      : null;
-  const sunsetPct =
-    sunsetIndex !== undefined && samples.length > 1
-      ? (sunsetIndex / (samples.length - 1)) * 100
-      : null;
-  const sunriseTime =
-    sunriseIndex !== undefined && sunriseTz
-      ? formatLocal(new Date(samples[sunriseIndex].utc), sunriseTz, "HH:mm")
-      : null;
-  const sunsetTime =
-    sunsetIndex !== undefined && sunsetTz
-      ? formatLocal(new Date(samples[sunsetIndex].utc), sunsetTz, "HH:mm")
-      : null;
 
   return (
     <div className="mt-4 mx-auto w-full max-w-sm">
@@ -116,20 +86,6 @@ export default function PlaneSunViz({
       </div>
       {samples.length > 1 && (
         <div className="relative mt-2">
-          {sunrisePct !== null && sunriseTime && (
-            <SunEventMarker
-              type="sunrise"
-              time={sunriseTime}
-              style={{ left: `${sunrisePct}%`, top: -20, transform: "translate(-50%, -100%)" }}
-            />
-          )}
-          {sunsetPct !== null && sunsetTime && (
-            <SunEventMarker
-              type="sunset"
-              time={sunsetTime}
-              style={{ left: `${sunsetPct}%`, top: -20, transform: "translate(-50%, -100%)" }}
-            />
-          )}
           <input
             type="range"
             min={0}

--- a/components/ResultCard.tsx
+++ b/components/ResultCard.tsx
@@ -119,19 +119,22 @@ export default function ResultCard({ rec, origin, dest, preference, sampleIndex,
 
       {rec.samples && rec.samples.length > 1 && (
         <div className="text-zinc-700 dark:text-zinc-200">
-          <SunSparkline samples={rec.samples} tz={origin?.tz} />
+          <SunSparkline
+            samples={rec.samples}
+            tz={origin?.tz}
+            sunriseIndex={rec.sunriseSampleIndex}
+            sunsetIndex={rec.sunsetSampleIndex}
+            sunriseTz={rec.sunriseTz || origin?.tz}
+            sunsetTz={rec.sunsetTz || dest?.tz}
+          />
         </div>
       )}
 
       {rec.samples && rec.samples.length > 0 && (
         <PlaneSunViz
           samples={rec.samples}
-          sunriseIndex={rec.sunriseSampleIndex}
-          sunsetIndex={rec.sunsetSampleIndex}
           index={sampleIndex}
           onIndexChange={onSampleIndexChange}
-          sunriseTz={rec.sunriseTz || origin?.tz}
-          sunsetTz={rec.sunsetTz || dest?.tz}
         />
       )}
 

--- a/components/SunSparkline.tsx
+++ b/components/SunSparkline.tsx
@@ -3,10 +3,27 @@
 import type { Sample } from "@/lib/types";
 import { useMemo } from "react";
 import { formatLocal } from "@/lib/time";
+import SunEventMarker from "@/components/SunEventMarker";
 
-type Props = { samples: Sample[]; height?: number; tz?: string };
+type Props = {
+  samples: Sample[];
+  height?: number;
+  tz?: string;
+  sunriseIndex?: number;
+  sunsetIndex?: number;
+  sunriseTz?: string;
+  sunsetTz?: string;
+};
 
-export default function SunSparkline({ samples, height = 80, tz }: Props) {
+export default function SunSparkline({
+  samples,
+  height = 80,
+  tz,
+  sunriseIndex,
+  sunsetIndex,
+  sunriseTz,
+  sunsetTz,
+}: Props) {
   // Reserve space on top for the legend so the path never overlaps it
   const LEGEND_SPACE = 34;
   const width = 560;
@@ -97,18 +114,33 @@ export default function SunSparkline({ samples, height = 80, tz }: Props) {
     lastIdx,
     fullPath,
     sunPath,
+    xScale,
   } = model;
 
+  const sunriseX =
+    sunriseIndex !== undefined ? xScale(sunriseIndex) : null;
+  const sunrisePct = sunriseX !== null ? (sunriseX / W) * 100 : null;
+  const sunriseTime =
+    sunriseIndex !== undefined && sunriseTz
+      ? formatLocal(new Date(samples[sunriseIndex].utc), sunriseTz, "HH:mm")
+      : null;
+  const sunsetX =
+    sunsetIndex !== undefined ? xScale(sunsetIndex) : null;
+  const sunsetPct = sunsetX !== null ? (sunsetX / W) * 100 : null;
+  const sunsetTime =
+    sunsetIndex !== undefined && sunsetTz
+      ? formatLocal(new Date(samples[sunsetIndex].utc), sunsetTz, "HH:mm")
+      : null;
+
   return (
-    <>
-    <svg
-      viewBox={`0 0 ${W} ${H}`}
-      width="100%"
-      height={H}
-      role="img"
-      aria-label="Sun altitude over flight time"
-      className="mt-3"
-    >
+    <div className="relative mt-3">
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        width="100%"
+        height={H}
+        role="img"
+        aria-label="Sun altitude over flight time"
+      >
       <defs>
         <linearGradient id="spark" x1="0" y1="0" x2="0" y2="1">
           <stop offset="0" stopColor="#fbbf24" stopOpacity="0.95" />
@@ -242,12 +274,34 @@ export default function SunSparkline({ samples, height = 80, tz }: Props) {
           last sun
         </text>
       </g>
-    </svg>
-    <div className="mt-1 flex justify-between text-[10px] text-zinc-500 dark:text-zinc-400">
-      {tickTimes.map((t, i) => (
-        <span key={i}>{t}</span>
-      ))}
+      </svg>
+      {sunrisePct !== null && sunriseTime && (
+        <SunEventMarker
+          type="sunrise"
+          time={sunriseTime}
+          style={{
+            left: `${sunrisePct}%`,
+            top: H,
+            transform: "translate(-50%, -100%)",
+          }}
+        />
+      )}
+      {sunsetPct !== null && sunsetTime && (
+        <SunEventMarker
+          type="sunset"
+          time={sunsetTime}
+          style={{
+            left: `${sunsetPct}%`,
+            top: H,
+            transform: "translate(-50%, -100%)",
+          }}
+        />
+      )}
+      <div className="mt-1 flex justify-between text-[10px] text-zinc-500 dark:text-zinc-400">
+        {tickTimes.map((t, i) => (
+          <span key={i}>{t}</span>
+        ))}
+      </div>
     </div>
-    </>
   );
 }

--- a/lib/cities.json
+++ b/lib/cities.json
@@ -449,5 +449,8 @@
     "lat": 23.1136,
     "lon": -82.3666,
     "tz": "America/Havana"
-  }
+  },
+  { "name": "Anchorage", "lat": 61.2181, "lon": -149.9003, "tz": "America/Anchorage" },
+  { "name": "Honolulu", "lat": 21.3069, "lon": -157.8583, "tz": "Pacific/Honolulu" },
+  { "name": "Reykjavik", "lat": 64.1466, "lon": -21.9426, "tz": "Atlantic/Reykjavik" }
 ]


### PR DESCRIPTION
## Summary
- extend city dataset with Anchorage, Honolulu, and Reykjavik
- render sunrise and sunset markers along the SunSparkline axis
- remove auto-arrival sync so departure and arrival times are independent

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898af4be5748333998770c44f700ac7