### PR TITLE
Prevent sun jump at slider end

### DIFF
--- a/lib/geo.ts
+++ b/lib/geo.ts
@@ -80,8 +80,9 @@ export function intermediatePoint(a: P, b: P, f: number): P {
  */
 export function trackAt(a: P, b: P, f: number): number {
   const eps = 1e-6;
-  const f2 = Math.min(1, Math.max(0, f + eps));
-  const p1 = intermediatePoint(a, b, f);
+  const f1 = Math.max(0, Math.min(1, f - eps));
+  const f2 = Math.max(0, Math.min(1, f + eps));
+  const p1 = intermediatePoint(a, b, f1);
   const p2 = intermediatePoint(a, b, f2);
   return initialBearing(p1, p2);
 }

--- a/tests/geo.test.ts
+++ b/tests/geo.test.ts
@@ -3,6 +3,7 @@ import {
   gcDistanceKm,
   initialBearing,
   intermediatePoint,
+  trackAt,
   splitAtAntimeridian,
 } from "../lib/geo";
 import { computeRecommendation } from "../lib/logic";
@@ -64,4 +65,9 @@ test("splitAtAntimeridian handles polar-crossing routes", () => {
       expect(diff).toBeLessThanOrEqual(180);
     }
   }
+});
+
+test("trackAt handles final fraction", () => {
+  const course = initialBearing({ lat: 0, lon: 0 }, { lat: 0, lon: 10 });
+  expect(trackAt({ lat: 0, lon: 0 }, { lat: 0, lon: 10 }, 1)).toBeCloseTo(course, 6);
 });


### PR DESCRIPTION
## Summary
- Fix trackAt to compute bearing around the selected fraction so the plane's orientation remains accurate at the end of a flight
- Add regression test for trackAt's final fraction behavior

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898b496f4d48333bb8519fe6b032efb