### PR TITLE
Add moving marker on sunline and hourly ticks

### DIFF
--- a/components/ResultCard.tsx
+++ b/components/ResultCard.tsx
@@ -126,6 +126,7 @@ export default function ResultCard({ rec, origin, dest, preference, sampleIndex,
             sunsetIndex={rec.sunsetSampleIndex}
             sunriseTz={rec.sunriseTz || origin?.tz}
             sunsetTz={rec.sunsetTz || dest?.tz}
+            index={sampleIndex}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary
- show slider position on the SunSparkline
- display all hours along the timeline axis

## Testing
- `npm test` (fails: Missing script: "test")
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898ba04dac08333bae5603c9fedd7b7