### PR TITLE
fix(viz): clamp progress, stabilize sun timeline

### DIFF
--- a/components/ResultCard.tsx
+++ b/components/ResultCard.tsx
@@ -1,7 +1,7 @@
 
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import type { Recommendation, Airport, Preference } from "@/lib/types";
 import { firstSunIndex, lastSunIndex, sampleLocalHM } from "@/lib/logic";
 import SunSparkline from "@/components/SunSparkline";
@@ -18,6 +18,12 @@ type Props = {
 
 export default function ResultCard({ rec, origin, dest, preference, sampleIndex, onSampleIndexChange }: Props) {
   const [copied, setCopied] = useState(false);
+  const [localIdx, setLocalIdx] = useState(sampleIndex);
+
+  useEffect(() => {
+    setLocalIdx(sampleIndex);
+  }, [sampleIndex]);
+
   if (!rec) return null;
 
   const total = rec.leftMinutes + rec.rightMinutes;
@@ -126,7 +132,7 @@ export default function ResultCard({ rec, origin, dest, preference, sampleIndex,
             sunsetIndex={rec.sunsetSampleIndex}
             sunriseTz={rec.sunriseTz || origin?.tz}
             sunsetTz={rec.sunsetTz || dest?.tz}
-            index={sampleIndex}
+            index={localIdx}
           />
         </div>
       )}
@@ -134,8 +140,12 @@ export default function ResultCard({ rec, origin, dest, preference, sampleIndex,
       {rec.samples && rec.samples.length > 0 && (
         <PlaneSunViz
           samples={rec.samples}
-          index={sampleIndex}
-          onIndexChange={onSampleIndexChange}
+          index={localIdx}
+          onScrub={setLocalIdx}
+          onIndexChange={(v) => {
+            setLocalIdx(v);
+            onSampleIndexChange(v);
+          }}
         />
       )}
 

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -1,0 +1,3 @@
+export function clamp(v: number, min: number, max: number) {
+  return Math.min(Math.max(v, min), max);
+}


### PR DESCRIPTION
## Summary
- add reusable clamp helper
- measure sparkline width, clamp index, and prevent overflow
- use unified Slider for sun visualization with scrub vs commit handling

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898de2a0ed48333964cab44081294cd