### PR TITLE
Synchronize sun visuals with timeline

### DIFF
--- a/components/Inputs.tsx
+++ b/components/Inputs.tsx
@@ -6,6 +6,7 @@ import type { Airport, Preference } from "@/lib/types";
 import IataCombo from "@/components/IataCombo";
 import { ArrowsRightLeftIcon } from "@heroicons/react/24/outline";
 import { convertLocalISO } from "@/lib/time";
+import { DateTime } from "luxon";
 import TimezoneSelect from "@/components/TimezoneSelect";
 import PreferenceToggle from "@/components/PreferenceToggle";
 import DateTime24 from "@/components/DateTime24";
@@ -162,18 +163,28 @@ export default function Inputs({ onSubmit, defaults, loading = false, onClearAll
     setTzMode((m) => (m === "origin" ? "dest" : m === "dest" ? "origin" : "custom"));
   }
 
-  function applyPreset(a: string, b: string, h = 7, m = 0) {
+  function applyPreset(
+    a: string,
+    b: string,
+    h = 7,
+    m = 0,
+    durMin?: number
+  ) {
     setFrom(a);
     setTo(b);
     setTzMode("origin");
     setPref("see");
-    const now = new Date();
-    const d = new Date(now.getFullYear(), now.getMonth(), now.getDate(), h, m);
-    const iso = new Date(d.getTime() - d.getTimezoneOffset() * 60000)
-      .toISOString()
-      .slice(0, 16);
-    setDepart(iso);
-    setArrive("");
+    const o = lookup(a);
+    const d = lookup(b);
+    const now = DateTime.now().setZone(o?.tz || "UTC");
+    const departDt = now.set({ hour: h, minute: m, second: 0, millisecond: 0 });
+    setDepart(departDt.toFormat("yyyy-LL-dd'T'HH:mm"));
+    if (o && d && durMin !== undefined) {
+      const arriveDt = departDt.plus({ minutes: durMin }).setZone(d.tz);
+      setArrive(arriveDt.toFormat("yyyy-LL-dd'T'HH:mm"));
+    } else {
+      setArrive("");
+    }
   }
 
   const chipKey = (onActivate: () => void) => (e: React.KeyboardEvent) => {
@@ -332,8 +343,8 @@ export default function Inputs({ onSubmit, defaults, loading = false, onClearAll
         </span>
         <button
           type="button"
-          onClick={() => applyPreset("DEL", "DXB", 18, 30)}
-          onKeyDown={chipKey(() => applyPreset("DEL", "DXB", 18, 30))}
+          onClick={() => applyPreset("DEL", "DXB", 18, 30, 210)}
+          onKeyDown={chipKey(() => applyPreset("DEL", "DXB", 18, 30, 210))}
           className="px-3 py-1.5 text-sm rounded-full border border-zinc-300 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition cursor-pointer"
           role="button"
         >
@@ -341,8 +352,8 @@ export default function Inputs({ onSubmit, defaults, loading = false, onClearAll
         </button>
         <button
           type="button"
-          onClick={() => applyPreset("SFO", "JFK", 7, 0)}
-          onKeyDown={chipKey(() => applyPreset("SFO", "JFK", 7, 0))}
+          onClick={() => applyPreset("SFO", "JFK", 7, 0, 330)}
+          onKeyDown={chipKey(() => applyPreset("SFO", "JFK", 7, 0, 330))}
           className="px-3 py-1.5 text-sm rounded-full border border-zinc-300 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition cursor-pointer"
           role="button"
         >
@@ -350,8 +361,8 @@ export default function Inputs({ onSubmit, defaults, loading = false, onClearAll
         </button>
         <button
           type="button"
-          onClick={() => applyPreset("LHR", "CDG", 16, 0)}
-          onKeyDown={chipKey(() => applyPreset("LHR", "CDG", 16, 0))}
+          onClick={() => applyPreset("LHR", "CDG", 16, 0, 75)}
+          onKeyDown={chipKey(() => applyPreset("LHR", "CDG", 16, 0, 75))}
           className="px-3 py-1.5 text-sm rounded-full border border-zinc-300 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition cursor-pointer"
           role="button"
         >

--- a/components/MapView.tsx
+++ b/components/MapView.tsx
@@ -129,7 +129,14 @@ export default function MapView({ samples, cities = [], thresholdKm = 75, sunris
 
         {/* plane marker */}
         <Pane name="plane-marker" style={{ zIndex: 650 }}>
-          {planeSample && <Marker position={[planeSample.lat, planeSample.lon]} icon={planeIcon} opacity={0.9} />}
+          {planeSample && (
+            <Marker
+              key={planeIndex}
+              position={[planeSample.lat, planeSample.lon]}
+              icon={planeIcon}
+              opacity={0.9}
+            />
+          )}
         </Pane>
 
         {/* sun markers (top) */}

--- a/components/PlaneSunViz.tsx
+++ b/components/PlaneSunViz.tsx
@@ -22,6 +22,7 @@ export default function PlaneSunViz({
   const containerRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(0);
   const [localIdx, setLocalIdx] = useState(index);
+  const prevIdxRef = useRef(index);
 
   useEffect(() => {
     const update = () => {
@@ -36,6 +37,7 @@ export default function PlaneSunViz({
 
   useEffect(() => {
     setLocalIdx(index);
+    prevIdxRef.current = index;
   }, [index]);
 
   if (!samples || samples.length === 0) return null;
@@ -44,6 +46,12 @@ export default function PlaneSunViz({
   const s = samples[idx];
   const rel = sunPlaneRelation(s.az, s.course, s.alt);
   const showSun = s.alt > 0;
+
+  const prevSample = samples[prevIdxRef.current];
+  const diffMinutes = Math.abs(
+    new Date(s.utc).getTime() - new Date(prevSample.utc).getTime()
+  ) / 60000;
+  const transitionSec = Math.max(0.1, Math.min(2, (diffMinutes / 5) * 0.3));
 
   const angleRad = (rel.relAz * Math.PI) / 180;
   const radius = width * (45 / 224);
@@ -95,6 +103,7 @@ export default function PlaneSunViz({
               height: sunSize,
               left: `calc(50% + ${sunX}px - ${sunSize / 2}px)`,
               top: `calc(50% + ${sunY}px - ${sunSize / 2}px)`,
+              transition: `left ${transitionSec}s linear, top ${transitionSec}s linear`,
             }}
           />
         )}

--- a/components/SunSparkline.tsx
+++ b/components/SunSparkline.tsx
@@ -129,7 +129,14 @@ export default function SunSparkline({
     return ticks;
   }, [samples, tz]);
 
-  if (!model) return null;
+  if (!model)
+    return (
+      <div
+        ref={containerRef}
+        style={{ height }}
+        className="relative mt-3 overflow-hidden rounded-lg"
+      />
+    );
 
   const {
     width: W,


### PR DESCRIPTION
## Summary
- Slow sun visualizer transitions to reflect actual time intervals
- Restore sparkline rendering with moving sun marker
- Examples now pre-fill arrival times
- Time scrubber updates plane marker on map

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898e142c1ac833394cd5be55b05af89