### PR TITLE
Synchronize sun visuals with timeline

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -78,6 +78,7 @@ export default function Home() {
     setRec(r);
     setOrigin(s.origin);
     setDest(s.dest);
+    setSampleIndex(0);
     updateUrl(s);
     setLoading(false);
   }

--- a/components/Inputs.tsx
+++ b/components/Inputs.tsx
@@ -6,6 +6,7 @@ import type { Airport, Preference } from "@/lib/types";
 import IataCombo from "@/components/IataCombo";
 import { ArrowsRightLeftIcon } from "@heroicons/react/24/outline";
 import { convertLocalISO } from "@/lib/time";
+import { DateTime } from "luxon";
 import TimezoneSelect from "@/components/TimezoneSelect";
 import PreferenceToggle from "@/components/PreferenceToggle";
 import DateTime24 from "@/components/DateTime24";
@@ -162,18 +163,28 @@ export default function Inputs({ onSubmit, defaults, loading = false, onClearAll
     setTzMode((m) => (m === "origin" ? "dest" : m === "dest" ? "origin" : "custom"));
   }
 
-  function applyPreset(a: string, b: string, h = 7, m = 0) {
+  function applyPreset(
+    a: string,
+    b: string,
+    h = 7,
+    m = 0,
+    durMin?: number
+  ) {
     setFrom(a);
     setTo(b);
     setTzMode("origin");
     setPref("see");
-    const now = new Date();
-    const d = new Date(now.getFullYear(), now.getMonth(), now.getDate(), h, m);
-    const iso = new Date(d.getTime() - d.getTimezoneOffset() * 60000)
-      .toISOString()
-      .slice(0, 16);
-    setDepart(iso);
-    setArrive("");
+    const o = lookup(a);
+    const d = lookup(b);
+    const now = DateTime.now().setZone(o?.tz || "UTC");
+    const departDt = now.set({ hour: h, minute: m, second: 0, millisecond: 0 });
+    setDepart(departDt.toFormat("yyyy-LL-dd'T'HH:mm"));
+    if (o && d && durMin !== undefined) {
+      const arriveDt = departDt.plus({ minutes: durMin }).setZone(d.tz);
+      setArrive(arriveDt.toFormat("yyyy-LL-dd'T'HH:mm"));
+    } else {
+      setArrive("");
+    }
   }
 
   const chipKey = (onActivate: () => void) => (e: React.KeyboardEvent) => {
@@ -332,8 +343,8 @@ export default function Inputs({ onSubmit, defaults, loading = false, onClearAll
         </span>
         <button
           type="button"
-          onClick={() => applyPreset("DEL", "DXB", 18, 30)}
-          onKeyDown={chipKey(() => applyPreset("DEL", "DXB", 18, 30))}
+          onClick={() => applyPreset("DEL", "DXB", 18, 30, 210)}
+          onKeyDown={chipKey(() => applyPreset("DEL", "DXB", 18, 30, 210))}
           className="px-3 py-1.5 text-sm rounded-full border border-zinc-300 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition cursor-pointer"
           role="button"
         >
@@ -341,8 +352,8 @@ export default function Inputs({ onSubmit, defaults, loading = false, onClearAll
         </button>
         <button
           type="button"
-          onClick={() => applyPreset("SFO", "JFK", 7, 0)}
-          onKeyDown={chipKey(() => applyPreset("SFO", "JFK", 7, 0))}
+          onClick={() => applyPreset("SFO", "JFK", 7, 0, 330)}
+          onKeyDown={chipKey(() => applyPreset("SFO", "JFK", 7, 0, 330))}
           className="px-3 py-1.5 text-sm rounded-full border border-zinc-300 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition cursor-pointer"
           role="button"
         >
@@ -350,8 +361,8 @@ export default function Inputs({ onSubmit, defaults, loading = false, onClearAll
         </button>
         <button
           type="button"
-          onClick={() => applyPreset("LHR", "CDG", 16, 0)}
-          onKeyDown={chipKey(() => applyPreset("LHR", "CDG", 16, 0))}
+          onClick={() => applyPreset("LHR", "CDG", 16, 0, 75)}
+          onKeyDown={chipKey(() => applyPreset("LHR", "CDG", 16, 0, 75))}
           className="px-3 py-1.5 text-sm rounded-full border border-zinc-300 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition cursor-pointer"
           role="button"
         >

--- a/components/MapView.tsx
+++ b/components/MapView.tsx
@@ -129,7 +129,13 @@ export default function MapView({ samples, cities = [], thresholdKm = 75, sunris
 
         {/* plane marker */}
         <Pane name="plane-marker" style={{ zIndex: 650 }}>
-          {planeSample && <Marker position={[planeSample.lat, planeSample.lon]} icon={planeIcon} opacity={0.9} />}
+          {planeSample && (
+            <Marker
+              position={[planeSample.lat, planeSample.lon]}
+              icon={planeIcon}
+              opacity={0.9}
+            />
+          )}
         </Pane>
 
         {/* sun markers (top) */}

--- a/components/PlaneSunViz.tsx
+++ b/components/PlaneSunViz.tsx
@@ -38,12 +38,35 @@ export default function PlaneSunViz({
     setLocalIdx(index);
   }, [index]);
 
-  if (!samples || samples.length === 0) return null;
+  const prevIdxRef = useRef(0);
 
-  const idx = clamp(localIdx, 0, samples.length - 1);
+  const hasSamples = !!samples && samples.length > 0;
+  const safeLen = hasSamples ? samples.length : 1;
+  const idx = clamp(localIdx, 0, safeLen - 1);
+
+  useEffect(() => {
+    prevIdxRef.current = idx;
+  }, [idx]);
+
+  if (!hasSamples) return null;
+
   const s = samples[idx];
   const rel = sunPlaneRelation(s.az, s.course, s.alt);
   const showSun = s.alt > 0;
+
+  // Animate the sun between samples at a speed proportional to the
+  // elapsed time between the current and previous sample. This keeps the
+  // sun movement in sync with real time, regardless of slider speed.
+  const prevIdx = prevIdxRef.current;
+  const prevUtc = samples[prevIdx]?.utc;
+  const currUtc = s.utc;
+  let transitionSec = 0;
+  if (prevUtc) {
+    const diffSec =
+      (new Date(currUtc).getTime() - new Date(prevUtc).getTime()) / 1000;
+    // Cap the transition so large jumps don't take excessively long.
+    transitionSec = Math.max(0, Math.min(diffSec, 5));
+  }
 
   const angleRad = (rel.relAz * Math.PI) / 180;
   const radius = width * (45 / 224);
@@ -95,6 +118,7 @@ export default function PlaneSunViz({
               height: sunSize,
               left: `calc(50% + ${sunX}px - ${sunSize / 2}px)`,
               top: `calc(50% + ${sunY}px - ${sunSize / 2}px)`,
+              transition: `left ${transitionSec}s linear, top ${transitionSec}s linear`,
             }}
           />
         )}

--- a/components/ResultCard.tsx
+++ b/components/ResultCard.tsx
@@ -1,7 +1,7 @@
 
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import type { Recommendation, Airport, Preference } from "@/lib/types";
 import { firstSunIndex, lastSunIndex, sampleLocalHM } from "@/lib/logic";
 import SunSparkline from "@/components/SunSparkline";
@@ -19,10 +19,21 @@ type Props = {
 export default function ResultCard({ rec, origin, dest, preference, sampleIndex, onSampleIndexChange }: Props) {
   const [copied, setCopied] = useState(false);
   const [localIdx, setLocalIdx] = useState(sampleIndex);
+  const rafRef = useRef<number>();
 
   useEffect(() => {
     setLocalIdx(sampleIndex);
   }, [sampleIndex]);
+
+  useEffect(() => {
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    rafRef.current = requestAnimationFrame(() => {
+      onSampleIndexChange(localIdx);
+    });
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [localIdx, onSampleIndexChange]);
 
   if (!rec) return null;
 
@@ -144,7 +155,6 @@ export default function ResultCard({ rec, origin, dest, preference, sampleIndex,
           onScrub={setLocalIdx}
           onIndexChange={(v) => {
             setLocalIdx(v);
-            onSampleIndexChange(v);
           }}
         />
       )}

--- a/components/SunSparkline.tsx
+++ b/components/SunSparkline.tsx
@@ -129,7 +129,14 @@ export default function SunSparkline({
     return ticks;
   }, [samples, tz]);
 
-  if (!model) return null;
+  if (!model)
+    return (
+      <div
+        ref={containerRef}
+        style={{ height }}
+        className="relative mt-3 overflow-hidden rounded-lg"
+      />
+    );
 
   const {
     width: W,
@@ -326,8 +333,8 @@ export default function SunSparkline({
           time={sunriseTime}
           style={{
             left: `${sunrisePct}%`,
-            top: H,
-            transform: "translate(-50%, -100%)",
+            bottom: 0,
+            transform: "translateX(-50%)",
           }}
         />
       )}
@@ -337,8 +344,8 @@ export default function SunSparkline({
           time={sunsetTime}
           style={{
             left: `${sunsetPct}%`,
-            top: H,
-            transform: "translate(-50%, -100%)",
+            bottom: 0,
+            transform: "translateX(-50%)",
           }}
         />
       )}


### PR DESCRIPTION
## Summary
- slow sun movement by computing time delta between samples and applying proportional CSS transitions

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6898e142c1ac833394cd5be55b05af89