### PR TITLE
Smooth sun visuals and fix build errors

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { useMemo, useState } from "react";
+import { Suspense, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
 import Inputs, { InputsSnapshot } from "@/components/Inputs";
@@ -17,7 +17,15 @@ import cities from "@/lib/cities.json";
 
 const MapView = dynamic(() => import("@/components/MapView"), { ssr: false });
 
-export default function Home() {
+export default function Page() {
+  return (
+    <Suspense fallback={null}>
+      <Home />
+    </Suspense>
+  );
+}
+
+function Home() {
   const router = useRouter();
   const search = useSearchParams();
 
@@ -78,6 +86,7 @@ export default function Home() {
     setRec(r);
     setOrigin(s.origin);
     setDest(s.dest);
+    setSampleIndex(0);
     updateUrl(s);
     setLoading(false);
   }

--- a/components/Inputs.tsx
+++ b/components/Inputs.tsx
@@ -6,6 +6,7 @@ import type { Airport, Preference } from "@/lib/types";
 import IataCombo from "@/components/IataCombo";
 import { ArrowsRightLeftIcon } from "@heroicons/react/24/outline";
 import { convertLocalISO } from "@/lib/time";
+import { DateTime } from "luxon";
 import TimezoneSelect from "@/components/TimezoneSelect";
 import PreferenceToggle from "@/components/PreferenceToggle";
 import DateTime24 from "@/components/DateTime24";
@@ -119,6 +120,12 @@ export default function Inputs({ onSubmit, defaults, loading = false, onClearAll
     if (!depart) return setError("Choose a departure date & time.");
     if (!arrive) return setError("Arrival time unavailable.");
 
+    const zone = zoneForMode(tzMode);
+    const departDt = DateTime.fromISO(depart, { zone });
+    const arriveDt = DateTime.fromISO(arrive, { zone });
+    if (arriveDt < departDt)
+      return setError("Arrival time must be after departure time.");
+
     let departLocalAtOrigin = depart;
     let arriveLocalAtDest = arrive;
     if (tzMode === "dest") {
@@ -162,18 +169,28 @@ export default function Inputs({ onSubmit, defaults, loading = false, onClearAll
     setTzMode((m) => (m === "origin" ? "dest" : m === "dest" ? "origin" : "custom"));
   }
 
-  function applyPreset(a: string, b: string, h = 7, m = 0) {
+  function applyPreset(
+    a: string,
+    b: string,
+    h = 7,
+    m = 0,
+    durMin?: number
+  ) {
     setFrom(a);
     setTo(b);
     setTzMode("origin");
     setPref("see");
-    const now = new Date();
-    const d = new Date(now.getFullYear(), now.getMonth(), now.getDate(), h, m);
-    const iso = new Date(d.getTime() - d.getTimezoneOffset() * 60000)
-      .toISOString()
-      .slice(0, 16);
-    setDepart(iso);
-    setArrive("");
+    const o = lookup(a);
+    const d = lookup(b);
+    const now = DateTime.now().setZone(o?.tz || "UTC");
+    const departDt = now.set({ hour: h, minute: m, second: 0, millisecond: 0 });
+    setDepart(departDt.toFormat("yyyy-LL-dd'T'HH:mm"));
+    if (o && d && durMin !== undefined) {
+      const arriveDt = departDt.plus({ minutes: durMin }).setZone(d.tz);
+      setArrive(arriveDt.toFormat("yyyy-LL-dd'T'HH:mm"));
+    } else {
+      setArrive("");
+    }
   }
 
   const chipKey = (onActivate: () => void) => (e: React.KeyboardEvent) => {
@@ -332,8 +349,8 @@ export default function Inputs({ onSubmit, defaults, loading = false, onClearAll
         </span>
         <button
           type="button"
-          onClick={() => applyPreset("DEL", "DXB", 18, 30)}
-          onKeyDown={chipKey(() => applyPreset("DEL", "DXB", 18, 30))}
+          onClick={() => applyPreset("DEL", "DXB", 18, 30, 210)}
+          onKeyDown={chipKey(() => applyPreset("DEL", "DXB", 18, 30, 210))}
           className="px-3 py-1.5 text-sm rounded-full border border-zinc-300 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition cursor-pointer"
           role="button"
         >
@@ -341,8 +358,8 @@ export default function Inputs({ onSubmit, defaults, loading = false, onClearAll
         </button>
         <button
           type="button"
-          onClick={() => applyPreset("SFO", "JFK", 7, 0)}
-          onKeyDown={chipKey(() => applyPreset("SFO", "JFK", 7, 0))}
+          onClick={() => applyPreset("SFO", "JFK", 7, 0, 330)}
+          onKeyDown={chipKey(() => applyPreset("SFO", "JFK", 7, 0, 330))}
           className="px-3 py-1.5 text-sm rounded-full border border-zinc-300 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition cursor-pointer"
           role="button"
         >
@@ -350,8 +367,8 @@ export default function Inputs({ onSubmit, defaults, loading = false, onClearAll
         </button>
         <button
           type="button"
-          onClick={() => applyPreset("LHR", "CDG", 16, 0)}
-          onKeyDown={chipKey(() => applyPreset("LHR", "CDG", 16, 0))}
+          onClick={() => applyPreset("LHR", "CDG", 16, 0, 75)}
+          onKeyDown={chipKey(() => applyPreset("LHR", "CDG", 16, 0, 75))}
           className="px-3 py-1.5 text-sm rounded-full border border-zinc-300 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition cursor-pointer"
           role="button"
         >

--- a/components/MapView.tsx
+++ b/components/MapView.tsx
@@ -61,8 +61,18 @@ export default function MapView({ samples, cities = [], thresholdKm = 75, sunris
   const flatPoints = segments.flat().map(([lon, lat]) => ({ lat, lon }));
   const sunriseSample = sunriseIndex !== undefined ? samples[sunriseIndex] : null;
   const sunsetSample = sunsetIndex !== undefined ? samples[sunsetIndex] : null;
-  const sunriseIcon = L.divIcon({ className: "", html: "🌅", iconSize: [20, 20], iconAnchor: [10, 10] });
-  const sunsetIcon = L.divIcon({ className: "", html: "🌇", iconSize: [20, 20], iconAnchor: [10, 10] });
+  const sunriseIcon = L.divIcon({
+    className: "",
+    html: "<span style='font-size:24px'>🌅</span>",
+    iconSize: [28, 28],
+    iconAnchor: [14, 14],
+  });
+  const sunsetIcon = L.divIcon({
+    className: "",
+    html: "<span style='font-size:24px'>🌇</span>",
+    iconSize: [28, 28],
+    iconAnchor: [14, 14],
+  });
   const planeSample = planeIndex !== undefined ? samples[Math.min(planeIndex, samples.length - 1)] : null;
   const planeIcon = L.divIcon({
     className: "opacity-90",
@@ -129,7 +139,13 @@ export default function MapView({ samples, cities = [], thresholdKm = 75, sunris
 
         {/* plane marker */}
         <Pane name="plane-marker" style={{ zIndex: 650 }}>
-          {planeSample && <Marker position={[planeSample.lat, planeSample.lon]} icon={planeIcon} opacity={0.9} />}
+          {planeSample && (
+            <Marker
+              position={[planeSample.lat, planeSample.lon]}
+              icon={planeIcon}
+              opacity={0.9}
+            />
+          )}
         </Pane>
 
         {/* sun markers (top) */}

--- a/components/PlaneSunViz.tsx
+++ b/components/PlaneSunViz.tsx
@@ -38,12 +38,19 @@ export default function PlaneSunViz({
     setLocalIdx(index);
   }, [index]);
 
-  if (!samples || samples.length === 0) return null;
+  const hasSamples = !!samples && samples.length > 0;
+  const safeLen = hasSamples ? samples.length : 1;
+  const idx = clamp(localIdx, 0, safeLen - 1);
 
-  const idx = clamp(localIdx, 0, samples.length - 1);
+  if (!hasSamples) return null;
+
   const s = samples[idx];
   const rel = sunPlaneRelation(s.az, s.course, s.alt);
   const showSun = s.alt > 0;
+
+  // Small, fixed-duration transition keeps the sun responsive to the
+  // slider while avoiding jarring jumps.
+  const transitionSec = 0.15;
 
   const angleRad = (rel.relAz * Math.PI) / 180;
   const radius = width * (45 / 224);
@@ -95,6 +102,7 @@ export default function PlaneSunViz({
               height: sunSize,
               left: `calc(50% + ${sunX}px - ${sunSize / 2}px)`,
               top: `calc(50% + ${sunY}px - ${sunSize / 2}px)`,
+              transition: `left ${transitionSec}s linear, top ${transitionSec}s linear`,
             }}
           />
         )}

--- a/components/ResultCard.tsx
+++ b/components/ResultCard.tsx
@@ -1,7 +1,7 @@
 
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import type { Recommendation, Airport, Preference } from "@/lib/types";
 import { firstSunIndex, lastSunIndex, sampleLocalHM } from "@/lib/logic";
 import SunSparkline from "@/components/SunSparkline";
@@ -19,10 +19,21 @@ type Props = {
 export default function ResultCard({ rec, origin, dest, preference, sampleIndex, onSampleIndexChange }: Props) {
   const [copied, setCopied] = useState(false);
   const [localIdx, setLocalIdx] = useState(sampleIndex);
+  const rafRef = useRef<number | null>(null);
 
   useEffect(() => {
     setLocalIdx(sampleIndex);
   }, [sampleIndex]);
+
+  useEffect(() => {
+    if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    rafRef.current = requestAnimationFrame(() => {
+      onSampleIndexChange(localIdx);
+    });
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [localIdx, onSampleIndexChange]);
 
   if (!rec) return null;
 
@@ -144,7 +155,6 @@ export default function ResultCard({ rec, origin, dest, preference, sampleIndex,
           onScrub={setLocalIdx}
           onIndexChange={(v) => {
             setLocalIdx(v);
-            onSampleIndexChange(v);
           }}
         />
       )}

--- a/components/SunSparkline.tsx
+++ b/components/SunSparkline.tsx
@@ -129,7 +129,14 @@ export default function SunSparkline({
     return ticks;
   }, [samples, tz]);
 
-  if (!model) return null;
+  if (!model)
+    return (
+      <div
+        ref={containerRef}
+        style={{ height }}
+        className="relative mt-3 overflow-hidden rounded-lg"
+      />
+    );
 
   const {
     width: W,
@@ -326,8 +333,8 @@ export default function SunSparkline({
           time={sunriseTime}
           style={{
             left: `${sunrisePct}%`,
-            top: H,
-            transform: "translate(-50%, -100%)",
+            bottom: 0,
+            transform: "translateX(-50%)",
           }}
         />
       )}
@@ -337,8 +344,8 @@ export default function SunSparkline({
           time={sunsetTime}
           style={{
             left: `${sunsetPct}%`,
-            top: H,
-            transform: "translate(-50%, -100%)",
+            bottom: 0,
+            transform: "translateX(-50%)",
           }}
         />
       )}


### PR DESCRIPTION
## Summary
- keep sun marker in sync with the time slider via a short, fixed CSS transition
- fix build-time errors by initializing refs and wrapping `useSearchParams` in `Suspense`
- enlarge sunrise and sunset markers on the map for better visibility
- validate that the arrival time comes after the departure time

## Testing
- `npm run lint`
- `npx vitest run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898e142c1ac833394cd5be55b05af89