### PR TITLE
feat: add aviationstack API routes

### DIFF
--- a/pages/api/getAirportInfo.ts
+++ b/pages/api/getAirportInfo.ts
@@ -1,0 +1,44 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const IATA_CODE_PATTERN = /^[A-Za-z]{3}$/;
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).end("Method Not Allowed");
+  }
+
+  const codeRaw = Array.isArray(req.query.iata_code)
+    ? req.query.iata_code[0]
+    : req.query.iata_code;
+
+  if (typeof codeRaw !== "string" || !IATA_CODE_PATTERN.test(codeRaw)) {
+    return res.status(400).json({ error: "Invalid or missing iata_code" });
+  }
+
+  const iataCode = codeRaw.toUpperCase();
+  const apiKey = process.env.AVIATIONSTACK_API_KEY;
+  if (!apiKey) {
+    return res.status(500).json({ error: "Server configuration error" });
+  }
+
+  try {
+    const url = new URL("http://api.aviationstack.com/v1/airports");
+    url.searchParams.set("access_key", apiKey);
+    url.searchParams.set("iata_code", iataCode);
+
+    const response = await fetch(url.toString());
+    if (!response.ok) {
+      return res
+        .status(response.status)
+        .json({ error: "Failed to fetch airport info" });
+    }
+    const data = await response.json();
+    return res.status(200).json(data);
+  } catch {
+    return res.status(502).json({ error: "Upstream request failed" });
+  }
+}

--- a/pages/api/getFlightStatus.ts
+++ b/pages/api/getFlightStatus.ts
@@ -1,0 +1,44 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const FLIGHT_IATA_PATTERN = /^[A-Za-z0-9]{2,10}$/;
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).end("Method Not Allowed");
+  }
+
+  const flightIataRaw = Array.isArray(req.query.flight_iata)
+    ? req.query.flight_iata[0]
+    : req.query.flight_iata;
+
+  if (typeof flightIataRaw !== "string" || !FLIGHT_IATA_PATTERN.test(flightIataRaw)) {
+    return res.status(400).json({ error: "Invalid or missing flight_iata" });
+  }
+
+  const flightIata = flightIataRaw.toUpperCase();
+  const apiKey = process.env.AVIATIONSTACK_API_KEY;
+  if (!apiKey) {
+    return res.status(500).json({ error: "Server configuration error" });
+  }
+
+  try {
+    const url = new URL("http://api.aviationstack.com/v1/flights");
+    url.searchParams.set("access_key", apiKey);
+    url.searchParams.set("flight_iata", flightIata);
+
+    const response = await fetch(url.toString());
+    if (!response.ok) {
+      return res
+        .status(response.status)
+        .json({ error: "Failed to fetch flight status" });
+    }
+    const data = await response.json();
+    return res.status(200).json(data);
+  } catch {
+    return res.status(502).json({ error: "Upstream request failed" });
+  }
+}


### PR DESCRIPTION
## Summary
- add `/api/getFlightStatus` to validate `flight_iata` and proxy AviationStack flight lookups
- add `/api/getAirportInfo` to validate `iata_code` and proxy AviationStack airport lookups

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689b03fe87048333ac10b65cc4d92755