### PR TITLE
Add environment example and document API key setup

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+AVIATIONSTACK_API_KEY=your_key_here

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ SeatScape helps air travellers choose the perfect window seat. Given the origin,
 npm install
 ```
 
+### Environment variables
+
+Copy the example env file and set your AviationStack API key:
+
+```bash
+cp .env.local.example .env.local
+```
+
+Then edit `.env.local` to add your real `AVIATIONSTACK_API_KEY`. This file is ignored by git, so your key stays private.
+
 ### Run the development server
 
 ```bash


### PR DESCRIPTION
## Summary
- add `.env.local.example` with public site URL and AviationStack API key placeholder
- document env setup in README and note real keys stay out of version control

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689b04150aa483339ab5f4833686cbe7