### PR TITLE
test: add flight normalization and airport resolution tests

### DIFF
--- a/lib/airports.ts
+++ b/lib/airports.ts
@@ -1,0 +1,27 @@
+import data from "./airports.json";
+import type { Airport } from "./types";
+
+const byIata: Record<string, Airport> = {};
+for (const a of data as Airport[]) {
+  byIata[a.iata.toUpperCase()] = a;
+}
+
+export async function resolveAirport(code: string): Promise<Airport | null> {
+  const upper = code.toUpperCase();
+  const local = byIata[upper];
+  if (local) return local;
+  const res = await fetch(`/api/getAirportInfo?iata=${upper}`);
+  if (!res.ok) throw new Error("Failed to fetch airport info");
+  const info = await res.json();
+  if (!info) return null;
+  const airport: Airport = {
+    iata: info.iata,
+    name: info.name,
+    lat: info.lat,
+    lon: info.lon,
+    tz: info.tz,
+  };
+  byIata[upper] = airport;
+  return airport;
+}
+

--- a/lib/flightApi.ts
+++ b/lib/flightApi.ts
@@ -1,0 +1,26 @@
+export type NormalizedFlight = {
+  airline: string;
+  flightNumber: string;
+  departure: { iata: string; time: string };
+  arrival: { iata: string; time: string };
+};
+
+export function normalizeFlight(raw: any): NormalizedFlight {
+  return {
+    airline: raw.airline?.name ?? "",
+    flightNumber: raw.flight?.iata ?? raw.flight?.number ?? "",
+    departure: {
+      iata: raw.departure?.iata ?? "",
+      time: raw.departure?.scheduled
+        ? new Date(raw.departure.scheduled).toISOString()
+        : "",
+    },
+    arrival: {
+      iata: raw.arrival?.iata ?? "",
+      time: raw.arrival?.scheduled
+        ? new Date(raw.arrival.scheduled).toISOString()
+        : "",
+    },
+  };
+}
+

--- a/tests/airportResolve.test.ts
+++ b/tests/airportResolve.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { resolveAirport } from "../lib/airports";
+
+const realFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = realFetch;
+});
+
+test("resolveAirport returns data from local dataset", async () => {
+  const fetchMock = vi.fn();
+  // @ts-expect-error override
+  global.fetch = fetchMock;
+  const a = await resolveAirport("DEL");
+  expect(a).toBeTruthy();
+  expect(a?.iata).toBe("DEL");
+  expect(fetchMock).not.toHaveBeenCalled();
+});
+
+test("resolveAirport falls back to API", async () => {
+  const apiData = {
+    iata: "ZZZ",
+    name: "Test Airport",
+    lat: 1,
+    lon: 2,
+    tz: "Etc/UTC",
+  };
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => apiData,
+  });
+  // @ts-expect-error override
+  global.fetch = fetchMock;
+  const a = await resolveAirport("ZZZ");
+  expect(a).toEqual(apiData);
+  expect(fetchMock).toHaveBeenCalledWith("/api/getAirportInfo?iata=ZZZ");
+});
+

--- a/tests/flightApi.test.ts
+++ b/tests/flightApi.test.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "vitest";
+import { normalizeFlight } from "../lib/flightApi";
+
+test("normalizeFlight converts Aviationstack data", () => {
+  const sample = {
+    airline: { name: "Emirates" },
+    flight: { number: "511", iata: "EK511" },
+    departure: {
+      airport: "Indira Gandhi International Airport",
+      iata: "DEL",
+      scheduled: "2025-01-10T10:00:00+05:30",
+    },
+    arrival: {
+      airport: "Dubai International Airport",
+      iata: "DXB",
+      scheduled: "2025-01-10T12:30:00+04:00",
+    },
+  };
+
+  const norm = normalizeFlight(sample);
+
+  expect(norm).toEqual({
+    airline: "Emirates",
+    flightNumber: "EK511",
+    departure: { iata: "DEL", time: "2025-01-10T04:30:00.000Z" },
+    arrival: { iata: "DXB", time: "2025-01-10T08:30:00.000Z" },
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `normalizeFlight` utility for Aviationstack data
- resolve airports from dataset with API fallback
- test flight normalization and airport resolution

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689b0418154c8333aeba10c3ff45082c