### PR TITLE
Fix TypeScript errors and normalize flight times

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,10 +32,10 @@ function Home() {
 
   // Build defaults from the URL (?from=...&to=...&depart=...&arrive=...); otherwise empty
   const defaults = useMemo(() => {
-    const from = (search.get("from") || "").toUpperCase();
-    const to = (search.get("to") || "").toUpperCase();
-    const depart = search.get("depart") || "";
-    const arrive = search.get("arrive") || "";
+    const from = (search?.get("from") || "").toUpperCase();
+    const to = (search?.get("to") || "").toUpperCase();
+    const depart = search?.get("depart") || "";
+    const arrive = search?.get("arrive") || "";
     return { from, to, depart, arrive };
   }, [search]);
 

--- a/lib/flightApi.ts
+++ b/lib/flightApi.ts
@@ -43,16 +43,21 @@ function selectTime(seg: ApiSegment) {
 }
 
 export function normalizeFlight(raw: ApiFlight): NormalizedFlight {
+  const toUtc = (seg?: ApiSegment) => {
+    const time = selectTime(seg ?? {});
+    return time ? DateTime.fromISO(time).toUTC().toISO() ?? "" : "";
+  };
+
   return {
     airline: raw.airline?.name ?? "",
     flightNumber: raw.flight?.iata ?? raw.flight?.number ?? "",
     departure: {
       iata: raw.departure?.iata ?? "",
-      time: selectTime(raw.departure ?? {}) ?? "",
+      time: toUtc(raw.departure),
     },
     arrival: {
       iata: raw.arrival?.iata ?? "",
-      time: selectTime(raw.arrival ?? {}) ?? "",
+      time: toUtc(raw.arrival),
     },
   };
 }

--- a/tests/airportResolve.test.ts
+++ b/tests/airportResolve.test.ts
@@ -9,7 +9,6 @@ afterEach(() => {
 
 test("resolveAirport returns data from local dataset", async () => {
   const fetchMock = vi.fn();
-  // @ts-expect-error override
   global.fetch = fetchMock;
   const a = await resolveAirport("DEL");
   expect(a).toBeTruthy();
@@ -29,7 +28,6 @@ test("resolveAirport falls back to API", async () => {
     ok: true,
     json: async () => apiData,
   });
-  // @ts-expect-error override
   global.fetch = fetchMock;
   const a = await resolveAirport("ZZZ");
   expect(a).toEqual(apiData);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
         "name": "next"
       }
     ],
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals", "node"]
   },
   "include": [
     "**/*.ts",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from "vitest/config";
+import path from "path";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname),
+    },
+  },
   test: {
     environment: "node",
     include: ["tests/**/*.test.ts"],


### PR DESCRIPTION
## Summary
- remove unnecessary `@ts-expect-error` usage in airport resolve tests
- configure Vitest to resolve `@` paths and include Node types
- normalize flight times to UTC and handle nullable search params

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689b085e6d9c833389c37c3c652186bd