### PR TITLE
Implement flight inputs builder

### DIFF
--- a/lib/flight.ts
+++ b/lib/flight.ts
@@ -1,4 +1,5 @@
 import type { Airport, Preference } from "@/lib/types";
+import { buildInputsFromFlight as buildInputsFromFlightApi } from "@/lib/flightApi";
 
 export type FlightInputs = {
   origin: Airport;
@@ -9,8 +10,11 @@ export type FlightInputs = {
 };
 
 export async function buildInputsFromFlight(
-  _flightNumber: string,
-  _date: string
+  flightNumber: string,
+  date: string
 ): Promise<FlightInputs> {
-  throw new Error("buildInputsFromFlight not implemented");
+  const snapshot = await buildInputsFromFlightApi(flightNumber, date);
+  if (!snapshot) throw new Error("Flight not found");
+  const { origin, dest, departLocalISO, arriveLocalISO, preference } = snapshot;
+  return { origin, dest, departLocalISO, arriveLocalISO, preference };
 }


### PR DESCRIPTION
## Summary
- implement buildInputsFromFlight using existing API utility

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689b0cc00ca083339eebe4eee8dc8e9a