### PR TITLE
Fix flight status API query param

### DIFF
--- a/lib/flightApi.ts
+++ b/lib/flightApi.ts
@@ -32,7 +32,7 @@ function resolveAirport(code: string): Airport | undefined {
 }
 
 export async function fetchFlightByIata(flightIata: string) {
-  const params = new URLSearchParams({ flightIata });
+  const params = new URLSearchParams({ flight_iata: flightIata });
   const res = await fetch(`/api/getFlightStatus?${params.toString()}`);
   if (!res.ok) throw new Error("Failed to fetch flight status");
   return res.json();

--- a/tests/flightApi.test.ts
+++ b/tests/flightApi.test.ts
@@ -1,5 +1,5 @@
-import { test, expect } from "vitest";
-import { normalizeFlight } from "../lib/flightApi";
+import { test, expect, vi } from "vitest";
+import { normalizeFlight, fetchFlightByIata } from "../lib/flightApi";
 
 test("normalizeFlight converts Aviationstack data", () => {
   const sample = {
@@ -25,5 +25,23 @@ test("normalizeFlight converts Aviationstack data", () => {
     departure: { iata: "DEL", time: "2025-01-10T04:30:00.000Z" },
     arrival: { iata: "DXB", time: "2025-01-10T08:30:00.000Z" },
   });
+});
+
+test("fetchFlightByIata calls API with flight_iata param", async () => {
+  const originalFetch = globalThis.fetch;
+  const mockFetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({}),
+  });
+  // @ts-expect-error allow mock assignment
+  globalThis.fetch = mockFetch;
+  try {
+    await fetchFlightByIata("AA100");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/getFlightStatus?flight_iata=AA100"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 


### PR DESCRIPTION
## Summary
- pass `flight_iata` when requesting flight status
- verify flight status lookup uses correct query param

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_689b12367e8c83338b1eac52538013d9